### PR TITLE
Clearing bitmap mviewlogs fix

### DIFF
--- a/BuildScripts/createModuleOwnerSchema.sql
+++ b/BuildScripts/createModuleOwnerSchema.sql
@@ -179,6 +179,8 @@ CREATE TABLE IF NOT EXISTS :MODULEOWNER.pg$mviews
 	inner_join_other_table_array	TEXT[],
 	inner_join_other_alias_array	TEXT[],
 	inner_join_other_rowid_array	TEXT[],
+	query_joins_multi_table_cnt_array	SMALLINT[],
+	query_joins_multi_table_pos_array	SMALLINT[],
     CONSTRAINT
             pk_pg$mviews
             PRIMARY KEY

--- a/BuildScripts/createModuleOwnerSchema.sql
+++ b/BuildScripts/createModuleOwnerSchema.sql
@@ -10,6 +10,7 @@ Date        | Name          | Description
             |               |
 12/11/2018  | M Revitt      | Initial version
 05/11/2019  | T Mullen      | Reflecting the changes of table names
+23/10/2020	| D Day			| Added new columns to pg$mviews table query_joins_multi_table_cnt_array and query_joins_multi_table_pos_array
 ------------+---------------+-------------------------------------------------------------------------------------------------------
 Background:     PostGre does not support Materialized View Fast Refreshes, this suite of scripts is a PL/SQL coded mechanism to
                 provide that functionality, the next phase of this projecdt is to fold these changes into the PostGre kernel.

--- a/BuildScripts/mvApplicationFunctions.sql
+++ b/BuildScripts/mvApplicationFunctions.sql
@@ -87,6 +87,9 @@ Revision History    Push Down List
 ------------------------------------------------------------------------------------------------------------------------------------
 Date        | Name          | Description
 ------------+---------------+-------------------------------------------------------------------------------------------------------
+22/10/2020	| D Day			| Defect fix - added two variables tQueryJoinsMultiTabCntArray and tQueryJoinsMultiTabPosArray to OUT
+							| array to handle DML changes being applied from materialized view log that get used more than once by
+							| the same stored query.
 29/06/2020	| D Day			| Defect fix - added new procedural variables to support DELETE statements for DML Type INSERT to resolve
 			|				| duplicate rows issue.
 03/06/2020	| D Day			| Changed function to procedure to allow support/control of COMMITS within the refresh process.
@@ -140,6 +143,8 @@ DECLARE
 	tInnerJoinOtherTableNameArray	TEXT[];
 	tInnerJoinOtherTableAliasArray	TEXT[];
 	tInnerJoinOtherTableRowidArray	TEXT[];
+	tQueryJoinsMultiTabCntArray		SMALLINT[];
+	tQueryJoinsMultiTabPosArray     SMALLINT[];
 
 BEGIN
 
@@ -172,7 +177,9 @@ BEGIN
 			pInnerJoinTableRowidArray,
 			pInnerJoinOtherTableNameArray,		
 			pInnerJoinOtherTableAliasArray,
-			pInnerJoinOtherTableRowidArray
+			pInnerJoinOtherTableRowidArray,
+			pQueryJoinsMultiTabCntArray,
+			pQueryJoinsMultiTabPosArray
 
     FROM
             mv$extractCompoundViewTables( rConst, tTableNames )
@@ -192,7 +199,9 @@ BEGIN
 			tInnerJoinTableRowidArray,
 			tInnerJoinOtherTableNameArray,		
 			tInnerJoinOtherTableAliasArray,
-			tInnerJoinOtherTableRowidArray;	
+			tInnerJoinOtherTableRowidArray,
+			tQueryJoinsMultiTabCntArray,
+			tQueryJoinsMultiTabPosArray;
 
     CALL mv$createPgMv$Table
                         (
@@ -238,6 +247,8 @@ BEGIN
 					tInnerJoinOtherTableNameArray,		
 					tInnerJoinOtherTableAliasArray,
 					tInnerJoinOtherTableRowidArray,
+					tQueryJoinsMultiTabCntArray,
+					tQueryJoinsMultiTabPosArray,
                     pFastRefresh
                 );
 				

--- a/BuildScripts/mvApplicationFunctions.sql
+++ b/BuildScripts/mvApplicationFunctions.sql
@@ -87,9 +87,10 @@ Revision History    Push Down List
 ------------------------------------------------------------------------------------------------------------------------------------
 Date        | Name          | Description
 ------------+---------------+-------------------------------------------------------------------------------------------------------
-22/10/2020	| D Day			| Defect fix - added two variables tQueryJoinsMultiTabCntArray and tQueryJoinsMultiTabPosArray to OUT
-							| array to handle DML changes being applied from materialized view log that get used more than once by
-							| the same stored query.
+22/10/2020	| D Day			| Defect fix - added two variables tQueryJoinsMultiTabCntArray and tQueryJoinsMultiTabPosArray to out in
+			|				| arrays to handle DML changes being applied from materialized view log table that gets used more than once by
+			|				| the same stored query. This procedure calls mv$insertPgMview to insert these new arrays into pg$mviews
+			|				| data dictionary table to support the refresh process.
 29/06/2020	| D Day			| Defect fix - added new procedural variables to support DELETE statements for DML Type INSERT to resolve
 			|				| duplicate rows issue.
 03/06/2020	| D Day			| Changed function to procedure to allow support/control of COMMITS within the refresh process.

--- a/BuildScripts/mvComplexFunctions.sql
+++ b/BuildScripts/mvComplexFunctions.sql
@@ -1716,7 +1716,8 @@ BEGIN
 							 1,
 							 i)-1);
 					tColumnNameSql := mv$regExpReplace(tColumnNameSql,'(^[[:space:]]+)',null);
-					tColumnNameSql := mv$regExpSubstr(REGEXP_REPLACE((tColumnNameSql),'\s+$', ''),'(.*'||tRegExpColumnNameAlias||'+[[:alnum:]]+(.*?[^,|$]))',1,1,'i');
+					tColumnNameSql := mv$regExpSubstr((tColumnNameSql),'(.*'||tRegExpColumnNameAlias||'+[[:alnum:]]+(.*?[^,|$]))',1,1,'i');
+					tColumnNameSql := mv$regExpReplace(tColumnNameSql,'\s+$','');
 					tMvColumnName  := TRIM(REPLACE(mv$regExpSubstr(tColumnNameSql, '\S+$'),',',''));
 					tMvColumnName  := LOWER(TRIM(REPLACE(tMvColumnName,tAlias,'')));
 					

--- a/BuildScripts/mvComplexFunctions.sql
+++ b/BuildScripts/mvComplexFunctions.sql
@@ -1716,7 +1716,7 @@ BEGIN
 							 1,
 							 i)-1);
 					tColumnNameSql := mv$regExpReplace(tColumnNameSql,'(^[[:space:]]+)',null);
-					tColumnNameSql := mv$regExpSubstr(REGEXP_REPLACE(tColumnNameSql),'\s+$', ''),'(.*'||tRegExpColumnNameAlias||'+[[:alnum:]]+(.*?[^,|$]))',1,1,'i');
+					tColumnNameSql := mv$regExpSubstr(REGEXP_REPLACE((tColumnNameSql),'\s+$', ''),'(.*'||tRegExpColumnNameAlias||'+[[:alnum:]]+(.*?[^,|$]))',1,1,'i');
 					tMvColumnName  := TRIM(REPLACE(mv$regExpSubstr(tColumnNameSql, '\S+$'),',',''));
 					tMvColumnName  := LOWER(TRIM(REPLACE(tMvColumnName,tAlias,'')));
 					

--- a/BuildScripts/mvComplexFunctions.sql
+++ b/BuildScripts/mvComplexFunctions.sql
@@ -1013,7 +1013,7 @@ BEGIN
 									
 					bOuterJoined := mv$checkIfOuterJoinedTable( pConst, aMultiTablePgMview.table_array[i], aMultiTablePgMview.outer_table_array[i] );
 								
-								cResult :=  mv$executeMVFastRefresh
+								CALL  mv$executeMVFastRefresh
 								(
 									pConst,
 									tLastType,

--- a/BuildScripts/mvComplexFunctions.sql
+++ b/BuildScripts/mvComplexFunctions.sql
@@ -949,7 +949,7 @@ BEGIN
 		
 			IF pQueryJoinsMultiTabPosArray > 1 THEN
 
-				FOR i IN ARRAY_LOWER( aMultiTablePgMview.table_array, 1 ) .. ARRAY_UPPER( aMultiTablePgMview.table_array, 1 )
+				FOR i IN ARRAY_LOWER( aMultiTablePgMview.table_array, 1 ) .. ARRAY_UPPER( aMultiTablePgMview.table_array, 1 ) LOOP
 
 					IF aMultiTablePgMview.table_array[i] = pTableName THEN
 					
@@ -1007,7 +1007,7 @@ BEGIN
 		
 			aMultiTablePgMview   := mv$getPgMviewTableData( pConst, pOwner, pViewName );
 
-			FOR i IN ARRAY_LOWER( aMultiTablePgMview.table_array, 1 ) .. ARRAY_UPPER( aMultiTablePgMview.table_array, 1 )
+			FOR i IN ARRAY_LOWER( aMultiTablePgMview.table_array, 1 ) .. ARRAY_UPPER( aMultiTablePgMview.table_array, 1 ) LOOP
 				
 				IF aMultiTablePgMview.table_array[i] = pTableName THEN
 									

--- a/BuildScripts/mvComplexFunctions.sql
+++ b/BuildScripts/mvComplexFunctions.sql
@@ -544,8 +544,8 @@ PROCEDURE    mv$insertPgMview
 				pInnerJoinOtherTableNameArray	IN		TEXT[],		
 				pInnerJoinOtherTableAliasArray	IN		TEXT[],
 				pInnerJoinOtherTableRowidArray	IN		TEXT[],
-				pQueryJoinsMultiTabCntArray IN SMALLINT[],
-				pQueryJoinsMultiTabPosArray IN SMALLINT[],
+				pQueryJoinsMultiTabCntArray 	IN SMALLINT[],
+				pQueryJoinsMultiTabPosArray 	IN SMALLINT[],
                 pFastRefresh        IN      BOOLEAN
             )
 AS

--- a/BuildScripts/mvComplexFunctions.sql
+++ b/BuildScripts/mvComplexFunctions.sql
@@ -544,8 +544,8 @@ PROCEDURE    mv$insertPgMview
 				pInnerJoinOtherTableNameArray	IN		TEXT[],		
 				pInnerJoinOtherTableAliasArray	IN		TEXT[],
 				pInnerJoinOtherTableRowidArray	IN		TEXT[],
-				pQueryJoinsMultiTabCntArray 	IN SMALLINT[],
-				pQueryJoinsMultiTabPosArray 	IN SMALLINT[],
+				pQueryJoinsMultiTabCntArray 	IN 		SMALLINT[],
+				pQueryJoinsMultiTabPosArray 	IN 		SMALLINT[],
                 pFastRefresh        IN      BOOLEAN
             )
 AS
@@ -1159,7 +1159,8 @@ Revision History    Push Down List
 Date        | Name          | Description
 ------------+---------------+-------------------------------------------------------------------------------------------------------
 22/10/2020  | D Day			| Defect fix - Added logic to handle processing table_array DML changes that link to the same materialized view
-			|				| log.
+			|				| log. The refresh will ONLY be executed when the query joins multi table position is equal to 1 - otherwise it
+			|				| will ignore as this is now handled in the calling procedure.
 08/06/2020	| D Day			| Added sub begin and end block to capture EXCEPTION handler as this is not support in procedures using a COMMIT.
 			|				| By adding to an independant block enables exception handling to be coded. Anything outside of this block will
 			|				| be handled as the default Postgres error handler. 

--- a/BuildScripts/mvSimpleFunctions.sql
+++ b/BuildScripts/mvSimpleFunctions.sql
@@ -2606,9 +2606,6 @@ DECLARE
 	iTableCount		  INTEGER;
 	
 	iCounter		  INTEGER := 0;
-	
-	tTableArray  TEXT[] := '{}';
-	
 
 BEGIN
 

--- a/BuildScripts/mvSimpleFunctions.sql
+++ b/BuildScripts/mvSimpleFunctions.sql
@@ -1380,8 +1380,8 @@ BEGIN
 
     END LOOP;
 	
-	CALL mv$setQueryJoinsMultiTablePosition(pConst,pTableArray,pInnerAliasArray,pQueryJoinsMultiTabPosArray);
-	CALL mv$setQueryJoinsMultiTableCount(pConst,pTableArray,pInnerAliasArray,pQueryJoinsMultiTabCntArray);	
+	CALL mv$setQueryJoinsMultiTablePosition(pTableArray,pInnerAliasArray,pQueryJoinsMultiTabPosArray);
+	CALL mv$setQueryJoinsMultiTableCount(pTableArray,pInnerAliasArray,pQueryJoinsMultiTabCntArray);	
 
     RETURN;
 
@@ -2489,7 +2489,6 @@ LANGUAGE    plpgsql;
 CREATE OR REPLACE
 PROCEDURE    mv$setQueryJoinsMultiTablePosition
             (
-                pConst          			IN   mv$allConstants,
                 pTableNames         		IN   TEXT[],
                 pAliasArray         		IN   TEXT[],
 				pQueryJoinsMultiTabPosArray INOUT  SMALLINT[]		
@@ -2509,8 +2508,7 @@ Date        | Name          | Description
 ------------+---------------+-------------------------------------------------------------------------------------------------------
 Description:    Procedure to generate the query joins multi table position array for when the same table name is used more than once.
 
-Arguments:      IN      pConst              		The memory structure containing all constants
-                IN      pTableNames         
+Arguments:      IN      pTableNames         
                 IN      pAliasArray
                 INOUT     pQueryJoinsMultiTabPosArray
 				
@@ -2571,7 +2569,6 @@ LANGUAGE    plpgsql;
 CREATE OR REPLACE
 PROCEDURE    mv$setQueryJoinsMultiTableCount
             (
-                pConst          			IN   mv$allConstants,
                 pTableNames         		IN   TEXT[],
                 pAliasArray         		IN   TEXT[],
 				pQueryJoinsMultiTabCntArray			INOUT  SMALLINT[]		
@@ -2591,8 +2588,7 @@ Date        | Name          | Description
 ------------+---------------+-------------------------------------------------------------------------------------------------------
 Description:    Procedure to generate the query joins multi table total count array for when the same table name is used more than once.
 
-Arguments:      IN      pConst              		The memory structure containing all constants
-                IN      pTableNames         
+Arguments:      IN      pTableNames         
                 IN      pAliasArray
                 INOUT   pQueryJoinsMultiTabPosArray
 				

--- a/BuildScripts/mvSimpleFunctions.sql
+++ b/BuildScripts/mvSimpleFunctions.sql
@@ -2517,15 +2517,15 @@ Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-Lic
 ***********************************************************************************************************************************/
 DECLARE
 
-    rTableNames       RECORD;
+    rTableNames       	RECORD;
 	
-	iTableCount		  INTEGER;
+	iTableCount		  	INTEGER;
 	
-	iCounter		  INTEGER := 0;
+	iCounter		  	INTEGER := 0;
 	
-	tTableArray  TEXT[] := '{}';
+	tTableArray  		TEXT[] := '{}';
 	
-	iMultiTableCount INTEGER := 0;
+	iMultiTableCount 	INTEGER := 0;
 	
 
 BEGIN
@@ -2538,7 +2538,7 @@ FOR rTableNames IN (SELECT UNNEST(pTableNames) AS table_name, UNNEST(pAliasArray
 	FROM (SELECT UNNEST(pTableNames) AS table_name) inline
 	WHERE inline.table_name = rTableNames.table_name;
 	
-	tTableArray := rTableNames.table_name;
+	tTableArray[iCounter] := rTableNames.table_name;
 	
 	IF iTableCount = 1 THEN
 	
@@ -2547,7 +2547,7 @@ FOR rTableNames IN (SELECT UNNEST(pTableNames) AS table_name, UNNEST(pAliasArray
 	ELSE
 	
 		SELECT count(1) INTO iMultiTableCount
-		FROM (SELECT UNNEST(tTableArray)) inline
+		FROM (SELECT UNNEST(tTableArray) AS table_name) inline
 		WHERE inline.table_name = rTableNames.table_name;
 	
 		pQueryJoinsMultiTabPosArray[iCounter] := iMultiTableCount;		

--- a/BuildScripts/mvSimpleFunctions.sql
+++ b/BuildScripts/mvSimpleFunctions.sql
@@ -2492,7 +2492,7 @@ PROCEDURE    mv$setQueryJoinsMultiTablePosition
                 pConst          			IN   mv$allConstants,
                 pTableNames         		IN   TEXT[],
                 pAliasArray         		IN   TEXT[],
-				pQueryJoinsMultiTabPosArray			INOUT  SMALLINT[]		
+				pQueryJoinsMultiTabPosArray INOUT  SMALLINT[]		
             )
 AS
 $BODY$
@@ -2520,8 +2520,6 @@ Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-Lic
 DECLARE
 
     rTableNames       RECORD;
-
-    tSqlStatement 	  TEXT;
 	
 	iTableCount		  INTEGER;
 	
@@ -2591,12 +2589,12 @@ Date        | Name          | Description
 ------------+---------------+-------------------------------------------------------------------------------------------------------
 21/10/2020  | D Day         | Initial version
 ------------+---------------+-------------------------------------------------------------------------------------------------------
-Description:    Procedure to generate the query joins multi table position array for when the same table name is used more than once.
+Description:    Procedure to generate the query joins multi table total count array for when the same table name is used more than once.
 
 Arguments:      IN      pConst              		The memory structure containing all constants
                 IN      pTableNames         
                 IN      pAliasArray
-                INOUT     pQueryJoinsMultiTabPosArray
+                INOUT   pQueryJoinsMultiTabPosArray
 				
 ************************************************************************************************************************************
 Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: MIT-0
@@ -2604,16 +2602,12 @@ Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-Lic
 DECLARE
 
     rTableNames       RECORD;
-
-    tSqlStatement 	  TEXT;
 	
 	iTableCount		  INTEGER;
 	
 	iCounter		  INTEGER := 0;
 	
 	tTableArray  TEXT[] := '{}';
-	
-	iMultiTableCount INTEGER := 0;
 	
 
 BEGIN

--- a/BuildScripts/mvSimpleFunctions.sql
+++ b/BuildScripts/mvSimpleFunctions.sql
@@ -1090,6 +1090,10 @@ Revision History    Push Down List
 ------------------------------------------------------------------------------------------------------------------------------------
 Date        | Name          | Description
 ------------+---------------+-------------------------------------------------------------------------------------------------------
+23/10/2020	| D Day			| Defect fix - added OUT parameters pQueryJoinsMultiTabCntArray and pQueryJoinsMultiTabPosArray
+			|				| populated by calling procedures mv$setQueryJoinsMultiTablePosition and mv$setQueryJoinsMultiTableCount.
+			|				| Used to populated data dictionary table pg$mviews to resolve handling clearing mview log bitmap values
+			|				| for mview logs being processed more than once within the mview stored query.
 29/06/2020	| D Day			| Defect fix - added inner joinings details to resolve duplicate issue when row already exists for
 			|				| DML change type INSERT.
 12/02/2020	| D Day 		| Defect fix - changed logic to populate OUT parameters pInnerAliasArray and pInnerRowidArray correctly 

--- a/BuildScripts/mvSimpleFunctions.sql
+++ b/BuildScripts/mvSimpleFunctions.sql
@@ -85,8 +85,8 @@ DROP PROCEDURE IF EXISTS mv$createindexestemptable;
 DROP PROCEDURE IF EXISTS mv$dropmvindexes;
 DROP PROCEDURE IF EXISTS mv$readdmvindexes;
 DROP PROCEDURE IF EXISTS mv$dropindexestemptable;
-
-
+DROP PROCEDURE IF EXISTS mv$setQueryJoinsMultiTableCount;
+DROP PROCEDURE IF EXISTS mv$setQueryJoinsMultiTablePosition;
 
 ----------------------- Write CREATE-FUNCTION-stage scripts --------------------
 SET CLIENT_MIN_MESSAGES = NOTICE;
@@ -1074,7 +1074,9 @@ FUNCTION    mv$extractCompoundViewTables
 				pInnerJoinTableRowidArray		OUT TEXT[],
 				pInnerJoinOtherTableNameArray	OUT	TEXT[],		
 				pInnerJoinOtherTableAliasArray	OUT	TEXT[],
-				pInnerJoinOtherTableRowidArray	OUT TEXT[]
+				pInnerJoinOtherTableRowidArray	OUT TEXT[],
+				pQueryJoinsMultiTabCntArray		OUT SMALLINT[],
+				pQueryJoinsMultiTabPosArray		OUT SMALLINT[]
             )
     RETURNS RECORD
 AS
@@ -1192,6 +1194,8 @@ Arguments:      IN      pConst              	The memory structure containing all
 				OUT		pInnerJoinOtherTableNameArray	An array confirming the INNER JOIN other joining table names		
 				OUT		pInnerJoinOtherTableAliasArray	An array confirming the INNER JOIN other joining table aliases 
 				OUT		pInnerJoinOtherTableRowidArray	An array confirming the INNER JOIN other joining table rowid column names
+				OUT     pQueryJoinsMultiTabCntArray		An array containing the materialized view query joins multi table counts for each table alias if the table exists once or more
+				OUT     pQueryJoinsMultiTabPosArray		An array containing the materialized view query joins multi table position when table occurs once or more linked to each table alias
 					
 Returns:                RECORD              The ten out parameters
 ************************************************************************************************************************************
@@ -1376,7 +1380,8 @@ BEGIN
 
     END LOOP;
 	
-	
+	CALL mv$setQueryJoinsMultiTablePosition(pConst,pTableArray,pInnerAliasArray,pQueryJoinsMultiTabPosArray);
+	CALL mv$setQueryJoinsMultiTableCount(pConst,pTableArray,pInnerAliasArray,pQueryJoinsMultiTabCntArray);	
 
     RETURN;
 
@@ -2480,5 +2485,158 @@ BEGIN
 END ;
 $BODY$
 LANGUAGE    plpgsql;
+------------------------------------------------------------------------------------------------------------------------------------
+CREATE OR REPLACE
+PROCEDURE    mv$setQueryJoinsMultiTablePosition
+            (
+                pConst          			IN   mv$allConstants,
+                pTableNames         		IN   TEXT[],
+                pAliasArray         		IN   TEXT[],
+				pQueryJoinsMultiTabPosArray			INOUT  SMALLINT[]		
+            )
+AS
+$BODY$
+/* ---------------------------------------------------------------------------------------------------------------------------------
+Routine Name: mv$setQueryJoinsMultiTablePosition
+Author:       David Day
+Date:         21/10/2020
+------------------------------------------------------------------------------------------------------------------------------------
+Revision History    Push Down List
+------------------------------------------------------------------------------------------------------------------------------------
+Date        | Name          | Description
+------------+---------------+-------------------------------------------------------------------------------------------------------
+21/10/2020  | D Day         | Initial version
+------------+---------------+-------------------------------------------------------------------------------------------------------
+Description:    Procedure to generate the query joins multi table position array for when the same table name is used more than once.
 
+Arguments:      IN      pConst              		The memory structure containing all constants
+                IN      pTableNames         
+                IN      pAliasArray
+                INOUT     pQueryJoinsMultiTabPosArray
+				
+************************************************************************************************************************************
+Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: MIT-0
+***********************************************************************************************************************************/
+DECLARE
 
+    rTableNames       RECORD;
+
+    tSqlStatement 	  TEXT;
+	
+	iTableCount		  INTEGER;
+	
+	iCounter		  INTEGER := 0;
+	
+	tTableArray  TEXT[] := '{}';
+	
+	iMultiTableCount INTEGER := 0;
+	
+
+BEGIN
+
+FOR rTableNames IN (SELECT UNNEST(pTableNames) AS table_name, UNNEST(pAliasArray) AS alias_name) LOOP
+
+	iCounter 	:= iCounter +1;
+	
+	SELECT count(1) INTO iTableCount
+	FROM (SELECT UNNEST(pTableNames) AS table_name) inline
+	WHERE inline.table_name = rTableNames.table_name;
+	
+	tTableArray := rTableNames.table_name;
+	
+	IF iTableCount = 1 THEN
+	
+		pQueryJoinsMultiTabPosArray[iCounter] := 1;
+		
+	ELSE
+	
+		SELECT count(1) INTO iMultiTableCount
+		FROM (SELECT UNNEST(tTableArray)) inline
+		WHERE inline.table_name = rTableNames.table_name;
+	
+		pQueryJoinsMultiTabPosArray[iCounter] := iMultiTableCount;		
+	
+	END IF;
+
+END LOOP;
+
+EXCEPTION
+WHEN OTHERS
+THEN
+	RAISE INFO      'Exception in procedure mv$setQueryJoinsMultiTablePosition';
+	RAISE INFO      'Error %:- %:',     SQLSTATE, SQLERRM;
+	RAISE EXCEPTION '%',                SQLSTATE;
+END;
+$BODY$
+LANGUAGE    plpgsql;
+------------------------------------------------------------------------------------------------------------------------------------
+CREATE OR REPLACE
+PROCEDURE    mv$setQueryJoinsMultiTableCount
+            (
+                pConst          			IN   mv$allConstants,
+                pTableNames         		IN   TEXT[],
+                pAliasArray         		IN   TEXT[],
+				pQueryJoinsMultiTabCntArray			INOUT  SMALLINT[]		
+            )
+AS
+$BODY$
+/* ---------------------------------------------------------------------------------------------------------------------------------
+Routine Name: mv$setQueryJoinsMultiTableCount
+Author:       David Day
+Date:         21/10/2020
+------------------------------------------------------------------------------------------------------------------------------------
+Revision History    Push Down List
+------------------------------------------------------------------------------------------------------------------------------------
+Date        | Name          | Description
+------------+---------------+-------------------------------------------------------------------------------------------------------
+21/10/2020  | D Day         | Initial version
+------------+---------------+-------------------------------------------------------------------------------------------------------
+Description:    Procedure to generate the query joins multi table position array for when the same table name is used more than once.
+
+Arguments:      IN      pConst              		The memory structure containing all constants
+                IN      pTableNames         
+                IN      pAliasArray
+                INOUT     pQueryJoinsMultiTabPosArray
+				
+************************************************************************************************************************************
+Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: MIT-0
+***********************************************************************************************************************************/
+DECLARE
+
+    rTableNames       RECORD;
+
+    tSqlStatement 	  TEXT;
+	
+	iTableCount		  INTEGER;
+	
+	iCounter		  INTEGER := 0;
+	
+	tTableArray  TEXT[] := '{}';
+	
+	iMultiTableCount INTEGER := 0;
+	
+
+BEGIN
+
+FOR rTableNames IN (SELECT UNNEST(pTableNames) AS table_name, UNNEST(pAliasArray) AS alias_name) LOOP
+
+	iCounter 	:= iCounter +1;
+	
+	SELECT count(1) INTO iTableCount
+	FROM (SELECT UNNEST(pTableNames) AS table_name) inline
+	WHERE inline.table_name = rTableNames.table_name;
+	
+	pQueryJoinsMultiTabCntArray[iCounter] := iTableCount;
+
+END LOOP;
+
+EXCEPTION
+WHEN OTHERS
+THEN
+	RAISE INFO      'Exception in procedure mv$setQueryJoinsMultiTableCount';
+	RAISE INFO      'Error %:- %:',     SQLSTATE, SQLERRM;
+	RAISE EXCEPTION '%',                SQLSTATE;
+END;
+$BODY$
+LANGUAGE    plpgsql;
+------------------------------------------------------------------------------------------------------------------------------------

--- a/UpdateScripts/V501_update_query_joins_multi_table_columns.sql
+++ b/UpdateScripts/V501_update_query_joins_multi_table_columns.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE
-PROCEDURE    V501_update_query_joins_multi_table_columns()
+PROCEDURE    pgrs_mview.V501_update_query_joins_multi_table_columns()
 AS
 $BODY$
 /* ---------------------------------------------------------------------------------------------------------------------------------
@@ -110,6 +110,8 @@ FOR rPgMviews IN (SELECT owner, view_name, table_array, alias_array
 	iCounter := 0;
 	
 END LOOP;
+
+END IF;
 
 EXCEPTION
 WHEN OTHERS

--- a/UpdateScripts/V501_update_query_joins_multi_table_columns.sql
+++ b/UpdateScripts/V501_update_query_joins_multi_table_columns.sql
@@ -1,0 +1,126 @@
+CREATE OR REPLACE
+PROCEDURE    V501_update_query_joins_multi_table_columns()
+AS
+$BODY$
+/* ---------------------------------------------------------------------------------------------------------------------------------
+Routine Name: V501_update_query_joins_multi_table_columns
+Author:       David Day
+Date:         27/10/2020
+------------------------------------------------------------------------------------------------------------------------------------
+Revision History    Push Down List
+------------------------------------------------------------------------------------------------------------------------------------
+Date        | Name          | Description
+------------+---------------+-------------------------------------------------------------------------------------------------------
+27/10/2020  | D Day         | Initial version
+------------+---------------+-------------------------------------------------------------------------------------------------------
+Description:    One-off procedure to update existing builds with new columns query_joins_multi_table_cnt_array and 
+				query_joins_multi_table_pos_array including populating array columns with values for each mview.
+
+Arguments:      None
+				
+************************************************************************************************************************************
+Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: MIT-0
+***********************************************************************************************************************************/
+DECLARE
+
+    rTableNames       	RECORD;
+	
+	rPgMviews			RECORD;
+	
+	iTableCount		  	INTEGER;
+	
+	iCounter		  	INTEGER := 0;
+	
+	tTableArray  		TEXT[] := '{}';
+	
+	iMultiTableCount 	INTEGER := 0;
+	
+	iColumnCnt			INTEGER := 0;
+	
+	iQueryJoinsMultiTabPosArray			SMALLINT[] := '{}';
+	
+	iQueryJoinsMultiTabCntArray			SMALLINT[] := '{}';
+	
+
+BEGIN
+
+SELECT count(1) INTO iColumnCnt
+FROM information_schema.columns 
+WHERE table_name= 'pg$mviews'
+AND column_name='query_joins_multi_table_cnt_array' AND column_name='query_joins_multi_table_pos_array';
+
+IF iColumnCnt = 0 THEN
+
+	EXECUTE 'ALTER table pg$mviews ADD COLUMN query_joins_multi_table_cnt_array	SMALLINT[], ADD COLUMN query_joins_multi_table_pos_array SMALLINT[]';
+
+END IF;
+
+SELECT count(1) INTO iColumnCnt
+FROM information_schema.columns 
+WHERE table_name= 'pg$mviews'
+AND column_name='query_joins_multi_table_cnt_array' AND column_name='query_joins_multi_table_pos_array';
+
+IF iColumnCnt = 2 THEN
+
+FOR rPgMviews IN (SELECT owner, view_name, table_array, alias_array
+					FROM pg$mviews
+					WHERE query_joins_multi_table_cnt_array IS NULL AND query_joins_multi_table_pos_array IS NULL) LOOP
+					
+					
+	FOR rTableNames IN (SELECT UNNEST(rPgMviews.table_array) AS table_name, UNNEST(rPgMviews.alias_array) AS alias_name) LOOP
+	
+		iCounter 	:= iCounter +1;
+	
+		SELECT count(1) INTO iTableCount
+		FROM (SELECT UNNEST(pTableNames) AS table_name) inline
+		WHERE inline.table_name = rTableNames.table_name;
+		
+		tTableArray[iCounter] := rTableNames.table_name;
+		
+		IF iTableCount = 1 THEN
+		
+			iQueryJoinsMultiTabPosArray[iCounter] := 1;
+			
+		ELSE
+		
+			SELECT count(1) INTO iMultiTableCount
+			FROM (SELECT UNNEST(tTableArray) AS table_name) inline
+			WHERE inline.table_name = rTableNames.table_name;
+		
+			iQueryJoinsMultiTabPosArray[iCounter] := iMultiTableCount;		
+		
+		END IF;
+		
+		SELECT count(1) INTO iTableCount
+		FROM (SELECT UNNEST(rPgMviews.table_array) AS table_name) inline
+		WHERE inline.table_name = rTableNames.table_name;
+		
+		iQueryJoinsMultiTabCntArray[iCounter] := iTableCount;
+		
+	END LOOP;
+	
+	UPDATE pg$mviews a
+	SET a.query_joins_multi_table_cnt_array = iQueryJoinsMultiTabCntArray
+	,   a.query_joins_multi_table_pos_array = iQueryJoinsMultiTabPosArray
+	WHERE a.view_name = rPgMviews.view_name;
+	
+	iQueryJoinsMultiTabCntArray := '{}';
+	iQueryJoinsMultiTabPosArray := '{}';
+	tTableArray					:= '{}';
+	iCounter := 0;
+	
+END LOOP;
+
+EXCEPTION
+WHEN OTHERS
+THEN
+	RAISE INFO      'Exception in procedure V501_update_query_joins_multi_table_columns';
+	RAISE INFO      'Error %:- %:',     SQLSTATE, SQLERRM;
+	RAISE EXCEPTION '%',                SQLSTATE;
+END;
+$BODY$
+LANGUAGE    plpgsql;
+
+CALL V501_update_query_joins_multi_table_columns();
+
+DROP PROCEDURE V501_update_query_joins_multi_table_columns;

--- a/UpdateScripts/V501_update_query_joins_multi_table_columns.sql
+++ b/UpdateScripts/V501_update_query_joins_multi_table_columns.sql
@@ -47,7 +47,7 @@ BEGIN
 SELECT count(1) INTO iColumnCnt
 FROM information_schema.columns 
 WHERE table_name= 'pg$mviews'
-AND column_name='query_joins_multi_table_cnt_array' AND column_name='query_joins_multi_table_pos_array';
+AND column_name='query_joins_multi_table_cnt_array' OR column_name='query_joins_multi_table_pos_array';
 
 IF iColumnCnt = 0 THEN
 
@@ -58,7 +58,7 @@ END IF;
 SELECT count(1) INTO iColumnCnt
 FROM information_schema.columns 
 WHERE table_name= 'pg$mviews'
-AND column_name='query_joins_multi_table_cnt_array' AND column_name='query_joins_multi_table_pos_array';
+AND column_name='query_joins_multi_table_cnt_array' OR column_name='query_joins_multi_table_pos_array';
 
 IF iColumnCnt = 2 THEN
 
@@ -72,7 +72,7 @@ FOR rPgMviews IN (SELECT owner, view_name, table_array, alias_array
 		iCounter 	:= iCounter +1;
 	
 		SELECT count(1) INTO iTableCount
-		FROM (SELECT UNNEST(pTableNames) AS table_name) inline
+		FROM (SELECT UNNEST(rPgMviews.table_array) AS table_name) inline
 		WHERE inline.table_name = rTableNames.table_name;
 		
 		tTableArray[iCounter] := rTableNames.table_name;
@@ -99,10 +99,13 @@ FOR rPgMviews IN (SELECT owner, view_name, table_array, alias_array
 		
 	END LOOP;
 	
-	UPDATE pg$mviews a
-	SET a.query_joins_multi_table_cnt_array = iQueryJoinsMultiTabCntArray
-	,   a.query_joins_multi_table_pos_array = iQueryJoinsMultiTabPosArray
-	WHERE a.view_name = rPgMviews.view_name;
+	--RAISE INFO '%', iQueryJoinsMultiTabCntArray;
+	--RAISE INFO '%', iQueryJoinsMultiTabPosArray;
+	
+	UPDATE pg$mviews
+	SET query_joins_multi_table_cnt_array = iQueryJoinsMultiTabCntArray
+	,   query_joins_multi_table_pos_array = iQueryJoinsMultiTabPosArray
+	WHERE view_name = rPgMviews.view_name;
 	
 	iQueryJoinsMultiTabCntArray := '{}';
 	iQueryJoinsMultiTabPosArray := '{}';

--- a/UpdateScripts/V502_update_pgmviews_oj_details_column_update_sql.sql
+++ b/UpdateScripts/V502_update_pgmviews_oj_details_column_update_sql.sql
@@ -1,0 +1,722 @@
+CREATE OR REPLACE
+FUNCTION    V502_mv$extractCompoundViewTables
+            (
+                rConst              IN      mv$allConstants,
+                pTableNames         IN      TEXT,
+                pTableArray           OUT   TEXT[],
+                pAliasArray           OUT   TEXT[],
+                pRowidArray           OUT   TEXT[],
+                pOuterTableArray      OUT   TEXT[],
+                pInnerAliasArray      OUT   TEXT[],
+                pInnerRowidArray      OUT   TEXT[],
+				rOuterLeftAliasArray  OUT	TEXT[],
+				tOuterLeftAliasArray OUT	TEXT[],
+				rLeftOuterJoinArray   OUT	TEXT[],
+				tRightOuterJoinArray  OUT	TEXT[],
+				pInnerJoinTableNameArray	OUT	TEXT[],
+				pInnerJoinTableAliasArray	OUT	TEXT[],
+				pInnerJoinTableRowidArray		OUT TEXT[],
+				pInnerJoinOtherTableNameArray	OUT	TEXT[],		
+				pInnerJoinOtherTableAliasArray	OUT	TEXT[],
+				pInnerJoinOtherTableRowidArray	OUT TEXT[]
+            )
+    RETURNS RECORD
+AS
+$BODY$
+DECLARE
+
+    tOuterTable     TEXT    := NULL;
+    tInnerAlias     TEXT    := rConst.NO_INNER_TOKEN;
+    tInnerRowid     TEXT    := rConst.NO_INNER_TOKEN;
+    tTableName      TEXT;
+    tTableNames     TEXT;
+    tTableAlias     TEXT;
+    iTableArryPos   INTEGER := rConst.ARRAY_LOWER_VALUE;
+	
+	tOuterLeftAlias  TEXT;
+	tOuterRightAlias TEXT;
+	tLeftOuterJoin 	 TEXT;
+	tRightOuterJoin  TEXT;
+	
+	tInnerLeftAlias  			TEXT;
+	tInnerRightAlias 			TEXT;
+	tInnerJoinTableAlias		TEXT;
+	tInnerJoinTableName			TEXT;
+	tInnerJoinTableRowid		TEXT;
+	tInnerJoinOtherTableAlias	TEXT;
+	tInnerJoinOtherTableName	TEXT;
+	tInnerJoinOtherTableRowid	TEXT;
+	
+	tInnerJoin					CHAR(1);
+	
+	iLoopCounter				INTEGER := 0;
+	iJoinCount					INTEGER := 0;
+
+BEGIN
+--  Replacing a single space with a double space is only required on the first pass to ensure that there is padding around all
+--  special commands so we can find then in the future replace statments
+    tTableNames :=  REPLACE(                            pTableNames, rConst.SPACE_CHARACTER,  rConst.DOUBLE_SPACE_CHARACTERS );
+    tTableNames :=  mv$replaceCommandWithToken( rConst, tTableNames, rConst.JOIN_DML_TYPE,    rConst.JOIN_TOKEN );
+    tTableNames :=  mv$replaceCommandWithToken( rConst, tTableNames, rConst.ON_DML_TYPE,      rConst.ON_TOKEN );
+    tTableNames :=  mv$replaceCommandWithToken( rConst, tTableNames, rConst.OUTER_DML_TYPE,   rConst.OUTER_TOKEN );
+    tTableNames :=  mv$replaceCommandWithToken( rConst, tTableNames, rConst.INNER_DML_TYPE,   rConst.COMMA_CHARACTER );
+    tTableNames :=  mv$replaceCommandWithToken( rConst, tTableNames, rConst.LEFT_DML_TYPE,    rConst.COMMA_LEFT_TOKEN );
+    tTableNames :=  mv$replaceCommandWithToken( rConst, tTableNames, rConst.RIGHT_DML_TYPE,   rConst.COMMA_RIGHT_TOKEN );
+    tTableNames :=  REPLACE( REPLACE(                   tTableNames, rConst.NEW_LINE,         rConst.EMPTY_STRING ),
+                                                                     rConst.CARRIAGE_RETURN,  rConst.EMPTY_STRING );
+
+    tTableNames :=  tTableNames || rConst.COMMA_CHARACTER; -- A trailling comma is required so we can detect the final table
+
+    WHILE POSITION( rConst.COMMA_CHARACTER IN tTableNames ) > 0
+    LOOP
+	
+		iLoopCounter := iLoopCounter + 1;
+		
+		tOuterLeftAlias  := NULL;
+		tOuterRightAlias := NULL;
+		tLeftOuterJoin 	 := NULL;
+		tRightOuterJoin  := NULL;
+        tOuterTable := NULL;
+        tInnerAlias := NULL;
+        tInnerRowid := NULL;
+		
+		tInnerLeftAlias  := NULL;
+		tInnerRightAlias := NULL;
+		tInnerJoinTableName	 := NULL;
+		tInnerJoinTableAlias := NULL;
+		tInnerJoinOtherTableName  := NULL;
+		tInnerJoinOtherTableAlias := NULL;
+		tInnerJoinTableRowid 	  := NULL;
+		tInnerJoinOtherTableRowid := NULL;
+		tInnerJoin	:= 'N';
+
+        tTableName := LTRIM( SPLIT_PART( tTableNames, rConst.COMMA_CHARACTER, 1 ));
+
+        IF POSITION( rConst.RIGHT_TOKEN IN tTableName ) > 0
+        THEN
+            tOuterTable := pAliasArray[iTableArryPos - 1];  -- There has to be a table preceeding a right outer join
+			
+			tOuterLeftAlias := TRIM(SUBSTRING(tTableName,POSITION( rConst.ON_TOKEN IN tTableName)+2,(mv$regExpInstr(tTableName,'\.',1,1))-(POSITION( rConst.ON_TOKEN IN tTableName)+2)));
+			tOuterRightAlias := TRIM(SUBSTRING(tTableName,POSITION( TRIM(rConst.EQUALS_COMMAND) IN tTableName)+1,(mv$regExpInstr(tTableName,'\.',1,2))-(POSITION( TRIM(rConst.EQUALS_COMMAND) IN tTableName)+1)));
+			tRightOuterJoin := rConst.RIGHT_OUTER_JOIN;
+			
+			tInnerAlias := tOuterRightAlias;
+			tInnerRowid := TRIM(REPLACE(REPLACE(tOuterRightAlias,'.','')||rConst.UNDERSCORE_CHARACTER||rConst.MV_M_ROW$_SOURCE_COLUMN,'"',''));
+			
+
+        ELSIF POSITION( rConst.LEFT_TOKEN IN tTableName ) > 0   -- There has to be a table preceeding a left outer join
+        THEN
+            tOuterTable := TRIM( SUBSTRING( tTableName,
+                                            POSITION( rConst.JOIN_TOKEN   IN tTableName ) + LENGTH( rConst.JOIN_TOKEN),
+                                            POSITION( rConst.ON_TOKEN     IN tTableName ) - LENGTH( rConst.ON_TOKEN)
+                                            - POSITION( rConst.JOIN_TOKEN IN tTableName )));	
+			
+			tOuterLeftAlias := TRIM(SUBSTRING(tTableName,POSITION( rConst.ON_TOKEN IN tTableName)+2,(mv$regExpInstr(tTableName,'\.',1,1))-(POSITION( rConst.ON_TOKEN IN tTableName)+2)));	
+			tOuterRightAlias := TRIM(SUBSTRING(tTableName,POSITION( TRIM(rConst.EQUALS_COMMAND) IN tTableName)+1,(mv$regExpInstr(tTableName,'\.',1,2))-(POSITION( TRIM(rConst.EQUALS_COMMAND) IN tTableName)+1)));
+			tLeftOuterJoin := rConst.LEFT_OUTER_JOIN;
+			
+            tInnerAlias := tOuterLeftAlias;
+			tInnerRowid := TRIM(REPLACE(REPLACE(tOuterLeftAlias,'.','')||rConst.UNDERSCORE_CHARACTER||rConst.MV_M_ROW$_SOURCE_COLUMN,'"',''));
+			
+		ELSIF POSITION( rConst.JOIN_TOKEN IN tTableName ) > 0
+		THEN	
+			tInnerLeftAlias		:= TRIM(SUBSTRING(tTableName,POSITION( rConst.ON_TOKEN IN tTableName)+2,(mv$regExpInstr(tTableName,'\.',1,1))-(POSITION( rConst.ON_TOKEN IN tTableName)+2))) || rConst.DOT_CHARACTER;	
+			tInnerRightAlias 	:= TRIM(SUBSTRING(tTableName,POSITION( TRIM(rConst.EQUALS_COMMAND) IN tTableName)+1,(mv$regExpInstr(tTableName,'\.',1,2))-(POSITION( TRIM(rConst.EQUALS_COMMAND) IN tTableName)+1))) || rConst.DOT_CHARACTER;
+			tInnerJoin			:= 'Y';
+			
+		END IF;
+
+        -- The LEFT, RIGHT and JOIN tokens are only required for outer join pattern matching
+        tTableName  := REPLACE( tTableName, rConst.JOIN_TOKEN,  rConst.EMPTY_STRING );
+        tTableName  := REPLACE( tTableName, rConst.LEFT_TOKEN,  rConst.EMPTY_STRING );
+        tTableName  := REPLACE( tTableName, rConst.RIGHT_TOKEN, rConst.EMPTY_STRING );
+        tTableName  := REPLACE( tTableName, rConst.OUTER_TOKEN, rConst.EMPTY_STRING );
+        tTableName  := LTRIM(   tTableName );
+
+        pTableArray[iTableArryPos]  := (REGEXP_SPLIT_TO_ARRAY( tTableName,  rConst.REGEX_MULTIPLE_SPACES ))[1];
+        tTableAlias                 := (REGEXP_SPLIT_TO_ARRAY( tTableName,  rConst.REGEX_MULTIPLE_SPACES ))[2];
+        pAliasArray[iTableArryPos]  :=  COALESCE( NULLIF( NULLIF( tTableAlias, rConst.EMPTY_STRING), rConst.ON_TOKEN),
+                                                                  pTableArray[iTableArryPos] ) || rConst.DOT_CHARACTER;
+		pRowidArray[iTableArryPos]  :=  mv$createRow$Column( rConst, pAliasArray[iTableArryPos] );
+		
+		IF tInnerJoin = 'Y' THEN
+		
+			tInnerJoinTableName		:= (REGEXP_SPLIT_TO_ARRAY( tTableName,  rConst.REGEX_MULTIPLE_SPACES ))[1];
+			tInnerJoinTableAlias    := (REGEXP_SPLIT_TO_ARRAY( tTableName,  rConst.REGEX_MULTIPLE_SPACES ))[2];
+			tInnerJoinTableAlias  	:=  COALESCE( NULLIF( NULLIF( tInnerJoinTableAlias, rConst.EMPTY_STRING), rConst.ON_TOKEN),
+																	  pTableArray[iTableArryPos] ) || rConst.DOT_CHARACTER;
+																	  
+			SELECT (CASE WHEN tInnerJoinTableAlias = tInnerLeftAlias THEN tInnerRightAlias
+					ELSE tInnerLeftAlias END) INTO tInnerJoinOtherTableAlias;
+					
+			SELECT inline.table_name
+			FROM (
+					SELECT 	UNNEST(pTableArray) AS table_name
+					,		UNNEST(pAliasArray) AS table_alias) inline
+			WHERE inline.table_alias = tInnerJoinOtherTableAlias
+			INTO tInnerJoinOtherTableName;
+			
+			tInnerJoinTableRowid	:= mv$createRow$Column( rConst, tInnerJoinTableAlias );
+			tInnerJoinOtherTableRowid	:= mv$createRow$Column( rConst, tInnerJoinOtherTableAlias );
+					
+		END IF;
+		
+		SELECT count(1) INTO iJoinCount FROM regexp_matches(pTableNames,rConst.JOIN_TOKEN,'g');
+		
+		IF iLoopCounter = 1 AND iJoinCount = 0 THEN
+		
+			tInnerJoinTableName			:= (REGEXP_SPLIT_TO_ARRAY( tTableName,  rConst.REGEX_MULTIPLE_SPACES ))[1];
+			tInnerJoinTableAlias    	:= (REGEXP_SPLIT_TO_ARRAY( tTableName,  rConst.REGEX_MULTIPLE_SPACES ))[2];
+			tInnerJoinTableAlias  		:=  COALESCE( NULLIF( NULLIF( tInnerJoinTableAlias, rConst.EMPTY_STRING), rConst.ON_TOKEN),
+																	  pTableArray[iTableArryPos] ) || rConst.DOT_CHARACTER;
+			tInnerJoinTableRowid		:= mv$createRow$Column( rConst, tInnerJoinTableAlias );
+			
+			tInnerJoinOtherTableName 	:= 'none';
+			tInnerJoinOtherTableRowid	:= 'none';
+			tInnerJoinOtherTableAlias	:= 'none';
+
+		END IF;
+			
+
+        pOuterTableArray[iTableArryPos]  :=(REGEXP_SPLIT_TO_ARRAY( tOuterTable, rConst.REGEX_MULTIPLE_SPACES ))[1];
+
+        tTableNames     := TRIM( SUBSTRING( tTableNames,
+                                 POSITION( rConst.COMMA_CHARACTER IN tTableNames ) + LENGTH( rConst.COMMA_CHARACTER )));
+								 
+		pInnerAliasArray[iTableArryPos] 		:= tInnerAlias;
+		pInnerRowidArray[iTableArryPos]			:= tInnerRowid;
+		
+		rOuterLeftAliasArray[iTableArryPos] 	:= tOuterLeftAlias;
+		tOuterLeftAliasArray[iTableArryPos] 	:= tOuterRightAlias;
+		rLeftOuterJoinArray[iTableArryPos] 		:= tLeftOuterJoin;
+		tRightOuterJoinArray[iTableArryPos] 	:= tRightOuterJoin;
+		
+        iTableArryPos   := iTableArryPos + 1;
+
+    END LOOP;
+
+    RETURN;
+
+    EXCEPTION
+    WHEN OTHERS
+    THEN
+        RAISE INFO      'Exception in function v502_mv$extractCompoundViewTables';
+        RAISE INFO      'Error %:- %:',     SQLSTATE, SQLERRM;
+        RAISE INFO      'Error Context:% %',CHR(10),  tTableNames;
+        RAISE EXCEPTION '%',                SQLSTATE;
+END;
+$BODY$
+LANGUAGE    plpgsql;
+
+CREATE OR REPLACE
+PROCEDURE    v502_update_pgmviews_oj_details_column_update_sql()
+AS
+$BODY$
+/* ---------------------------------------------------------------------------------------------------------------------------------
+Routine Name: v502_update_pgmviews_oj_details_column_update_sql
+Author:       David Day
+Date:         28/10/2020
+------------------------------------------------------------------------------------------------------------------------------------
+Revision History    Push Down List
+------------------------------------------------------------------------------------------------------------------------------------
+Date        | Name          | Description
+------------+---------------+-------------------------------------------------------------------------------------------------------
+28/10/2020  | D Day      	| Initial version
+------------+---------------+-------------------------------------------------------------------------------------------------------
+Description:    One-off procedure to update the affected data dictionary values held in table pg$mviews_oj_details column update_sql.
+
+Arguments:      None
+
+************************************************************************************************************************************
+Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: MIT-0
+***********************************************************************************************************************************/
+DECLARE
+
+    rConst              			mv$allConstants;
+	
+	rMain							RECORD;
+	
+	iColumnNameAliasCnt				INTEGER DEFAULT 0;	
+	
+	tRegexp_rowid					TEXT;
+	tSelectColumns					TEXT;
+	tColumnNameAlias				TEXT;
+	tRegExpColumnNameAlias			TEXT;
+	tColumnNameArray 				TEXT[];	
+	tColumnNameSql 					TEXT;
+	tMvColumnName					TEXT;
+	tTableName						TEXT;
+	tMvRowidColumnName				TEXT;
+	iMvColumnNameExists				INTEGER DEFAULT 0;	
+	iMvColumnNameLoopCnt			INTEGER DEFAULT 0;
+	
+	tUpdateSetSql					TEXT;
+	tSqlStatement					TEXT;
+	tWhereClause					TEXT;
+
+    rPgMviewColumnNames     		RECORD;
+	rMvOuterJoinDetails				RECORD;
+	rAliasJoinLinks					RECORD;
+	rBuildAliasArray				RECORD;
+	rMainAliasArray					RECORD;
+	rLeftOuterJoinAliasArray		RECORD;
+	rRightJoinAliasArray			RECORD;
+	rRightOuterJoinAliasArray		RECORD;
+	rLeftJoinAliasArray				RECORD;
+	
+	iWhileCounter					INTEGER DEFAULT 0;
+	iAliasJoinLinksCounter			INTEGER DEFAULT 0;	
+	iMainLoopCounter				INTEGER DEFAULT 0;
+	iWhileLoopCounter			    INTEGER DEFAULT 0;
+	iLoopCounter					INTEGER DEFAULT 0;
+	iRightLoopCounter				INTEGER DEFAULT 0;
+	iLeftAliasLoopCounter			INTEGER DEFAULT 0;
+	iRightAliasLoopCounter			INTEGER DEFAULT 0;
+	iLeftLoopCounter				INTEGER DEFAULT 0;
+	iColumnNameAliasLoopCnt			INTEGER DEFAULT 0;
+	
+	tOuterJoinAlias					TEXT;	
+	tAlias							TEXT;	
+	
+	tParentToChildAliasArray		TEXT[];	
+	tAliasArray						TEXT[];
+	tMainAliasArray					TEXT[];
+	tRightJoinAliasArray			TEXT[];
+	tBuildAliasArray				TEXT[];
+	tLeftJoinAliasArray				TEXT[];
+	
+	tRightJoinAliasExists			TEXT DEFAULT 'N';	
+	tLeftJoinAliasExists			TEXT DEFAULT 'N';
+	
+	tIsTrueOrFalse					TEXT;
+	
+	tClauseJoinReplacement			TEXT;
+
+-- Added compound variables
+
+    tRowidArray         	TEXT[];
+    tTableArray         	TEXT[];
+    tAliasArray         	TEXT[];
+    tOuterTableArray    	TEXT[];
+    tInnerAliasArray    	TEXT[];
+    tInnerRowidArray    	TEXT[];
+	tOuterLeftAliasArray 	TEXT[];
+	tOuterRightAliasArray 	TEXT[];
+	tLeftOuterJoinArray 	TEXT[];
+	tRightOuterJoinArray 	TEXT[];
+	tInnerJoinTableNameArray	TEXT[];
+	tInnerJoinTableAliasArray	TEXT[];
+	tInnerJoinTableRowidArray	TEXT[];
+	tInnerJoinOtherTableNameArray	TEXT[];
+	tInnerJoinOtherTableAliasArray	TEXT[];
+	tInnerJoinOtherTableRowidArray	TEXT[];
+	
+BEGIN
+
+    rConst      := mv$buildAllConstants();
+
+	FOR rMain IN (SELECT * FROM pg$mviews WHERE view_name IN (SELECT DISTINCT view_name
+															  FROM pg$mviews_oj_details
+															  WHERE update_sql NOT LIKE '% SET %' OR update_sql IS NULL)) LOOP
+															  
+															  
+		SELECT
+				pTableArray,
+				pAliasArray,
+				pRowidArray,
+				pOuterTableArray,
+				pInnerAliasArray,
+				pInnerRowidArray,
+				pOuterLeftAliasArray,
+				pOuterLeftAliasArray,
+				pLeftOuterJoinArray,
+				pRightOuterJoinArray,
+				pInnerJoinTableNameArray,
+				pInnerJoinTableAliasArray,
+				pInnerJoinTableRowidArray,
+				pInnerJoinOtherTableNameArray,		
+				pInnerJoinOtherTableAliasArray,
+				pInnerJoinOtherTableRowidArray
+
+		FROM
+				V501_mv$extractCompoundViewTables( rConst, rMain.table_names )
+		INTO
+				tTableArray,
+				tAliasArray,
+				tRowidArray,
+				tOuterTableArray,
+				tInnerAliasArray,
+				tInnerRowidArray,
+				tOuterLeftAliasArray,
+				tOuterRightAliasArray,
+				tLeftOuterJoinArray,
+				tRightOuterJoinArray,
+				tInnerJoinTableNameArray,
+				tInnerJoinTableAliasArray,
+				tInnerJoinTableRowidArray,
+				tInnerJoinOtherTableNameArray,		
+				tInnerJoinOtherTableAliasArray,
+				tInnerJoinOtherTableRowidArray;
+				
+		FOR rMvOuterJoinDetails IN (SELECT inline.oj_table AS table_name
+								,      inline.oj_table_alias AS table_name_alias
+								,	   inline.oj_rowid AS rowid_column_name
+								,      inline.oj_outer_left_alias AS outer_left_alias
+								,      inline.oj_outer_right_alias AS outer_right_alias
+								,      inline.oj_left_outer_join AS left_outer_join
+								,      inline.oj_right_outer_join AS right_outer_join
+								FROM (
+									SELECT 	UNNEST(tOuterTableArray) AS oj_table
+									, 		UNNEST(tAliasArray) AS oj_table_alias
+									, 		UNNEST(tRowidArray) AS oj_rowid
+								    ,       UNNEST(tOuterLeftAliasArray) AS oj_outer_left_alias
+									,		UNNEST(tOuterRightAliasArray) AS oj_outer_right_alias
+									,		UNNEST(tLeftOuterJoinArray) AS oj_left_outer_join
+									,		UNNEST(tRightOuterJoinArray) AS oj_right_outer_join) inline
+								WHERE inline.oj_table IS NOT NULL) LOOP
+	
+			iMainLoopCounter := iMainLoopCounter +1;		
+			tOuterJoinAlias := TRIM(REPLACE(rMvOuterJoinDetails.table_name_alias,'.',''));
+			iWhileLoopCounter := 0;
+			iWhileCounter := 0;	
+			tParentToChildAliasArray[iMainLoopCounter] := tOuterJoinAlias;
+			tAliasArray[iMainLoopCounter] := tOuterJoinAlias;
+											
+			WHILE iWhileCounter = 0 LOOP
+			
+				IF rMvOuterJoinDetails.left_outer_join = rConst.LEFT_OUTER_JOIN THEN			
+				
+					iWhileLoopCounter := iWhileLoopCounter +1;
+					tMainAliasArray := '{}';
+					
+					IF tAliasArray <> '{}' THEN
+				
+						tMainAliasArray[iWhileLoopCounter] := tAliasArray;
+		
+						FOR rMainAliasArray IN (SELECT UNNEST(tMainAliasArray) AS left_alias) LOOP
+						
+							tOuterJoinAlias := TRIM(REPLACE(rMainAliasArray.left_alias,'{',''));
+							tOuterJoinAlias := TRIM(REPLACE(tOuterJoinAlias,'}',''));
+							iLeftAliasLoopCounter := 0;
+						
+							FOR rLeftOuterJoinAliasArray IN (SELECT UNNEST(rOuterLeftAliasArray) as left_alias) LOOP
+					
+								IF rLeftOuterJoinAliasArray.left_alias = tOuterJoinAlias THEN
+									iLeftAliasLoopCounter := iLeftAliasLoopCounter +1;
+								END IF;
+				
+							END LOOP;
+							
+							IF iLeftAliasLoopCounter > 0 THEN 
+									
+								SELECT 	pChildAliasArray 
+								FROM 	mv$checkParentToChildOuterJoinAlias(
+																	rConst
+															,		tOuterJoinAlias
+															,		rMvOuterJoinDetails.left_outer_join
+															,		rOuterLeftAliasArray
+															,		tOuterLeftAliasArray
+															,		rLeftOuterJoinArray) 
+								INTO	tRightJoinAliasArray;
+
+								IF tRightJoinAliasArray = '{}' THEN
+									tRightJoinAliasExists := 'N';
+									--RAISE INFO 'No Left Aliases Match Right Aliases';
+								ELSE
+									iRightLoopCounter := 0;
+
+									FOR rRightJoinAliasArray IN (SELECT UNNEST(tRightJoinAliasArray) as right_join_alias) LOOP
+										
+										iRightLoopCounter := iRightLoopCounter +1;
+										iMainLoopCounter := iMainLoopCounter +1;
+										tParentToChildAliasArray[iMainLoopCounter] := rRightJoinAliasArray.right_join_alias;
+										tRightJoinAliasExists := 'Y';
+										tBuildAliasArray[iRightLoopCounter] := rRightJoinAliasArray.right_join_alias;
+
+									END LOOP;
+								END IF;
+
+								IF (tRightJoinAliasArray <> '{}' OR tRightJoinAliasExists = 'Y') THEN
+
+									tAliasArray := '{}';
+
+									FOR rBuildAliasArray IN (SELECT UNNEST(tBuildAliasArray) AS right_join_alias) LOOP
+
+										iLoopCounter = iLoopCounter +1;
+										iLeftAliasLoopCounter := 0;
+
+										FOR rLeftOuterJoinAliasArray IN (SELECT UNNEST(rOuterLeftAliasArray) AS left_alias) LOOP
+
+											IF rMainAliasArray.left_alias = rBuildAliasArray.right_join_alias THEN
+												iLeftAliasLoopCounter := iLeftAliasLoopCounter +1;
+											END IF;
+
+										END LOOP;
+
+										IF iLeftAliasLoopCounter > 0 THEN
+											tAliasArray[iLoopCounter] := rBuildAliasArray.right_join_alias;
+										END IF;
+
+									END LOOP;
+
+								ELSE
+
+									tRightJoinAliasExists = 'N';
+									tRightJoinAliasArray = '{}';
+									tAliasArray = '{}';
+
+								END IF;
+
+							ELSE
+							
+								tRightJoinAliasExists = 'N';
+								tRightJoinAliasArray = '{}';
+								tAliasArray = '{}';					
+							
+							END IF;
+							
+						END LOOP;
+					
+					ELSE
+						iWhileCounter := 1;	
+					END IF;
+					
+				ELSIF rMvOuterJoinDetails.right_outer_join = rConst.RIGHT_OUTER_JOIN THEN
+				
+					iWhileLoopCounter := iWhileLoopCounter +1;
+					tMainAliasArray := '{}';
+					
+					IF tAliasArray <> '{}' THEN
+				
+						tMainAliasArray[iWhileLoopCounter] := tAliasArray;
+		
+						FOR rMainAliasArray IN (SELECT UNNEST(tMainAliasArray) AS right_alias) LOOP
+						
+							tOuterJoinAlias := TRIM(REPLACE(rMainAliasArray.right_alias,'{',''));
+							tOuterJoinAlias := TRIM(REPLACE(tOuterJoinAlias,'}',''));
+							iRightAliasLoopCounter := 0;
+						
+							FOR rRightOuterJoinAliasArray IN (SELECT UNNEST(tOuterLeftAliasArray) as right_alias) LOOP
+					
+								IF rRightOuterJoinAliasArray.right_alias = tOuterJoinAlias THEN
+									iRightAliasLoopCounter := iRightAliasLoopCounter +1;
+								END IF;
+				
+							END LOOP;
+							
+							IF iRightAliasLoopCounter > 0 THEN 
+									
+								SELECT 	pChildAliasArray 
+								FROM 	mv$checkParentToChildOuterJoinAlias(
+																	rConst
+															,		tOuterJoinAlias
+															,		rMvOuterJoinDetails.right_outer_join
+															,		rOuterLeftAliasArray
+															,		tOuterLeftAliasArray
+															,		tRightOuterJoinArray) 
+								INTO	tLeftJoinAliasArray;
+
+								IF tLeftJoinAliasArray = '{}' THEN
+									tLeftJoinAliasExists := 'N';
+									--RAISE INFO 'No Right Aliases Match Left Aliases';
+								ELSE
+									iLeftLoopCounter := 0;
+
+									FOR rLeftJoinAliasArray IN (SELECT UNNEST(tLeftJoinAliasArray) as left_join_alias) LOOP
+										
+										iLeftLoopCounter := iLeftLoopCounter +1;
+										iMainLoopCounter := iMainLoopCounter +1;
+										tParentToChildAliasArray[iMainLoopCounter] := rLeftJoinAliasArray.left_join_alias;
+										tLeftJoinAliasExists := 'Y';
+										tBuildAliasArray[iLeftLoopCounter] := rLeftJoinAliasArray.left_join_alias;
+
+									END LOOP;
+								END IF;
+
+								IF (tLeftJoinAliasArray <> '{}' OR tLeftJoinAliasExists = 'Y') THEN
+
+									tAliasArray := '{}';
+
+									FOR rBuildAliasArray IN (SELECT UNNEST(tBuildAliasArray) AS left_join_alias) LOOP
+
+										iLoopCounter = iLoopCounter +1;
+										iRightAliasLoopCounter := 0;
+
+										FOR rRightOuterJoinAliasArray IN (SELECT UNNEST(tOuterLeftAliasArray) AS right_alias) LOOP
+
+											IF rMainAliasArray.right_alias = rBuildAliasArray.left_join_alias THEN
+												iRightAliasLoopCounter := iRightAliasLoopCounter +1;
+											END IF;
+
+										END LOOP;
+
+										IF iRightAliasLoopCounter > 0 THEN
+											tAliasArray[iLoopCounter] := rBuildAliasArray.left_join_alias;
+										END IF;
+
+									END LOOP;
+
+								ELSE
+
+									tLeftJoinAliasExists = 'N';
+									tLeftJoinAliasArray = '{}';
+									tAliasArray = '{}';
+
+								END IF;
+
+							ELSE
+							
+								tLeftJoinAliasExists = 'N';
+								tLeftJoinAliasArray = '{}';
+								tAliasArray = '{}';					
+							
+							END IF;
+							
+						END LOOP;
+					
+					ELSE
+						iWhileCounter := 1;	
+					END IF;
+				
+				END IF;
+				
+			END LOOP;
+			
+			-- Key values for the main UPDATE statement breakdown
+			tMvRowidColumnName 		:= rMvOuterJoinDetails.rowid_column_name;
+			tWhereClause 			:= rConst.WHERE_COMMAND || tMvRowidColumnName  || rConst.IN_ROWID_LIST;
+			tColumnNameAlias 		:= rMvOuterJoinDetails.table_name_alias;
+			tTableName 				:= rMvOuterJoinDetails.table_name;
+			tColumnNameArray	 	:= '{}';
+			tUpdateSetSql 		 	:= ' ';
+			iMvColumnNameLoopCnt 	:= 0;
+			iAliasJoinLinksCounter 	:= 0;
+			iColumnNameAliasLoopCnt := 0;
+			
+			-- Building the UPDATE statement including any child relationship columns and m_row$ based on these aliases
+			FOR rAliasJoinLinks IN (SELECT UNNEST(tParentToChildAliasArray) AS alias) LOOP
+			
+				IF rAliasJoinLinks.alias IS NOT NULL THEN
+			
+					iAliasJoinLinksCounter 	:= iAliasJoinLinksCounter +1;
+					tAlias 					:= rAliasJoinLinks.alias||'.';
+					tSelectColumns 			:= SUBSTRING(rMain.select_columns,1,mv$regExpInstr(rMain.select_columns,'[,]+[[:alnum:]]+[.]+'||'m_row\$'||''));
+					tRegExpColumnNameAlias 	:= REPLACE(tAlias,'.','\.');
+					iColumnNameAliasCnt 	:= mv$regExpCount(tSelectColumns, '[A-Za-z0-9]+('||tRegExpColumnNameAlias||')', 1);
+					iColumnNameAliasCnt 	:= mv$regExpCount(tSelectColumns, '('||tRegExpColumnNameAlias||')', 1) - iColumnNameAliasCnt;
+				
+					IF iColumnNameAliasCnt > 0 THEN
+				
+						FOR i IN 1..iColumnNameAliasCnt 
+						LOOP
+						
+							tColumnNameSql := SUBSTRING(tSelectColumns,mv$regExpInstr(tSelectColumns,
+									 '([^A-Za-z0-9]+('||tRegExpColumnNameAlias||'))',
+									 1,
+									 i)-1);
+							tColumnNameSql := mv$regExpReplace(tColumnNameSql,'(^[[:space:]]+)',null);
+							tColumnNameSql := mv$regExpSubstr((tColumnNameSql),'(.*'||tRegExpColumnNameAlias||'+[[:alnum:]]+(.*?[^,|$]))',1,1,'i');
+							tColumnNameSql := mv$regExpReplace(tColumnNameSql,'\s+$','');
+							tMvColumnName  := TRIM(REPLACE(mv$regExpSubstr(tColumnNameSql, '\S+$'),',',''));
+							tMvColumnName  := LOWER(TRIM(REPLACE(tMvColumnName,tAlias,'')));
+							
+							FOR rPgMviewColumnNames IN (SELECT column_name
+														FROM   information_schema.columns
+														WHERE  table_schema    = LOWER( rMain.owner )
+														AND    table_name      = LOWER( rMain.view_name ) )
+							LOOP
+							
+								IF rPgMviewColumnNames.column_name = tMvColumnName THEN
+												
+									iMvColumnNameLoopCnt := iMvColumnNameLoopCnt + 1;	
+
+									-- Check for duplicates
+									SELECT tMvColumnName = ANY (tColumnNameArray) INTO tIsTrueOrFalse;	
+									
+									IF tIsTrueOrFalse = 'false' THEN
+
+										iColumnNameAliasLoopCnt := iColumnNameAliasLoopCnt + 1;	
+										
+										tColumnNameArray[iColumnNameAliasLoopCnt] := tMvColumnName;
+										
+										IF iMvColumnNameLoopCnt = 1 THEN 	
+											tUpdateSetSql := rConst.SET_COMMAND || tMvColumnName || rConst.EQUALS_NULL || rConst.COMMA_CHARACTER;
+										ELSE	
+											tUpdateSetSql := tUpdateSetSql || tMvColumnName || rConst.EQUALS_NULL || rConst.COMMA_CHARACTER ;
+										END IF;
+										
+									END IF;
+								
+									EXIT WHEN iMvColumnNameLoopCnt > 0;
+									
+								END IF;
+
+							END LOOP;
+							
+						END LOOP;
+						
+						iColumnNameAliasLoopCnt := iColumnNameAliasLoopCnt + 1;
+						tColumnNameArray[iColumnNameAliasLoopCnt] := rAliasJoinLinks.alias|| rConst.UNDERSCORE_CHARACTER || rConst.MV_M_ROW$_COLUMN;
+						tUpdateSetSql := tUpdateSetSql || rAliasJoinLinks.alias|| rConst.UNDERSCORE_CHARACTER || rConst.MV_M_ROW$_COLUMN || rConst.EQUALS_NULL || rConst.COMMA_CHARACTER;
+						
+					ELSE
+						IF iAliasJoinLinksCounter = 1 THEN
+							iColumnNameAliasLoopCnt := iColumnNameAliasLoopCnt + 1;
+							tColumnNameArray[iColumnNameAliasLoopCnt] := rAliasJoinLinks.alias|| rConst.UNDERSCORE_CHARACTER || rConst.MV_M_ROW$_COLUMN;
+							tUpdateSetSql := rConst.SET_COMMAND || rAliasJoinLinks.alias|| rConst.UNDERSCORE_CHARACTER || rConst.MV_M_ROW$_COLUMN || rConst.EQUALS_NULL || rConst.COMMA_CHARACTER;			
+						ELSE
+							iColumnNameAliasLoopCnt := iColumnNameAliasLoopCnt + 1;
+							tColumnNameArray[iColumnNameAliasLoopCnt] := rAliasJoinLinks.alias|| rConst.UNDERSCORE_CHARACTER || rConst.MV_M_ROW$_COLUMN;
+							tUpdateSetSql := tUpdateSetSql || rAliasJoinLinks.alias || rConst.UNDERSCORE_CHARACTER || rConst.MV_M_ROW$_COLUMN || rConst.EQUALS_NULL || rConst.COMMA_CHARACTER;		
+						END IF;
+							
+					END IF;
+				
+				END IF;
+			
+			END LOOP;
+			
+			tUpdateSetSql := SUBSTRING(tUpdateSetSql,1,length(tUpdateSetSql)-1);
+			
+			tSqlStatement := rConst.UPDATE_COMMAND ||
+							 rMain.owner		|| rConst.DOT_CHARACTER		|| rMain.view_name	|| rConst.NEW_LINE		||
+							 tUpdateSetSql || rConst.NEW_LINE ||
+							 tWhereClause;
+							 
+			--tClauseJoinReplacement := mv$OuterJoinToInnerJoinReplacement(rConst, pTableNames, tColumnNameAlias);
+			
+			UPDATE pg$mviews_oj_details
+			SET update_sql = tSqlStatement
+			WHERE view_name = rMain.view_name
+			AND   owner		= rMain.owner
+			AND   table_alias = tColumnNameAlias;
+		
+			iMainLoopCounter := 0;
+			tParentToChildAliasArray := '{}';
+			tAliasArray  := '{}';
+			tMainAliasArray := '{}';
+			iWhileCounter := 0;
+			iWhileLoopCounter := 0;
+			iLoopCounter := 0;
+		
+		
+	END LOOP;
+	
+END LOOP;
+
+EXCEPTION
+WHEN OTHERS
+THEN
+	RAISE INFO      'Exception in procedure v502_update_pgmviews_oj_details_column_update_sql';
+	RAISE INFO      'Error %:- %:',     SQLSTATE, SQLERRM;
+	RAISE INFO      'Error Context:% %',CHR(10),  tSqlStatement;
+	RAISE EXCEPTION '%',                SQLSTATE;
+END;
+$BODY$
+LANGUAGE    plpgsql;
+
+CALL v502_update_pgmviews_oj_details_column_update_sql();
+
+DROP FUNCTION V502_mv$extractCompoundViewTables;
+DROP PROCEDURE v502_update_pgmviews_oj_details_column_update_sql;
+

--- a/UpdateScripts/V502_update_pgmviews_oj_details_column_update_sql.sql
+++ b/UpdateScripts/V502_update_pgmviews_oj_details_column_update_sql.sql
@@ -687,6 +687,7 @@ BEGIN
 			
 			UPDATE pg$mviews_oj_details
 			SET update_sql = tSqlStatement
+			,   column_name_array = tColumnNameArray
 			WHERE view_name = rMain.view_name
 			AND   owner		= rMain.owner
 			AND   table_alias = tColumnNameAlias;

--- a/UpdateScripts/V502_update_pgmviews_oj_details_column_update_sql.sql
+++ b/UpdateScripts/V502_update_pgmviews_oj_details_column_update_sql.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE
-FUNCTION    V502_mv$extractCompoundViewTables
+FUNCTION    pgrs_mview.V502_mv$extractCompoundViewTables
             (
                 rConst              IN      mv$allConstants,
                 pTableNames         IN      TEXT,
@@ -209,7 +209,7 @@ $BODY$
 LANGUAGE    plpgsql;
 
 CREATE OR REPLACE
-PROCEDURE    v502_update_pgmviews_oj_details_column_update_sql()
+PROCEDURE    pgrs_mview.v502_update_pgmviews_oj_details_column_update_sql()
 AS
 $BODY$
 /* ---------------------------------------------------------------------------------------------------------------------------------
@@ -296,7 +296,7 @@ DECLARE
 
     tRowidArray         	TEXT[];
     tTableArray         	TEXT[];
-    tAliasArray         	TEXT[];
+    xtAliasArray         	TEXT[];
     tOuterTableArray    	TEXT[];
     tInnerAliasArray    	TEXT[];
     tInnerRowidArray    	TEXT[];
@@ -342,7 +342,7 @@ BEGIN
 				V501_mv$extractCompoundViewTables( rConst, rMain.table_names )
 		INTO
 				tTableArray,
-				tAliasArray,
+				xtAliasArray,
 				tRowidArray,
 				tOuterTableArray,
 				tInnerAliasArray,
@@ -367,7 +367,7 @@ BEGIN
 								,      inline.oj_right_outer_join AS right_outer_join
 								FROM (
 									SELECT 	UNNEST(tOuterTableArray) AS oj_table
-									, 		UNNEST(tAliasArray) AS oj_table_alias
+									, 		UNNEST(xtAliasArray) AS oj_table_alias
 									, 		UNNEST(tRowidArray) AS oj_rowid
 								    ,       UNNEST(tOuterLeftAliasArray) AS oj_outer_left_alias
 									,		UNNEST(tOuterRightAliasArray) AS oj_outer_right_alias


### PR DESCRIPTION
Defect fix to resolve clearing bitmap rows in mview logs when materialized view stored query uses the base table more than once in the same query. And, applying changes to all occurrences if m_row$ value exists for that join condition.

Defect fix to resolve outer join update statements to nullify all relationship columns. Due to the format of the input SQL query this was not handling when there was a space after the comma, when the alias for example c. exists in another vc. and the loop was not considering blank relationships so was causing a small amount to be populated with null update_sql value on certain aliases for materialized views.