### PR TITLE
Primary Key Workaround

### DIFF
--- a/BuildScripts/mvComplexFunctions.sql
+++ b/BuildScripts/mvComplexFunctions.sql
@@ -2187,7 +2187,7 @@ BEGIN
     tSqlStatement := pConst.INSERT_INTO    || pOwner || pConst.DOT_CHARACTER    || aPgMview.view_name   ||
                      pConst.OPEN_BRACKET   || aPgMview.pgmv_columns             || pConst.CLOSE_BRACKET ||
                      --pConst.SELECT_COMMAND || aPgMview.select_columns           ||
-					 tSqlSelectColumns || pConst.FROM_COMMAND   || aPgMview.table_names
+					 tSqlSelectColumns || pConst.FROM_COMMAND   || aPgMview.table_names ||
                      pConst.WHERE_COMMAND;
 
     IF aPgMview.where_clause != pConst.EMPTY_STRING

--- a/BuildScripts/mvConstants.sql
+++ b/BuildScripts/mvConstants.sql
@@ -281,7 +281,8 @@ BEGIN
     rMvConstants.WHERE_COMMAND                  := ' WHERE ';
     rMvConstants.WHERE_NO_DATA                  := ' WHERE 1 = 2 ';
 	rMvConstants.LEFT_OUTER_JOIN				:= 'LOJ';
-	rMvConstants.RIGHT_OUTER_JOIN				:= 'ROJ';	
+	rMvConstants.RIGHT_OUTER_JOIN				:= 'ROJ';
+	rMvConstants.ON_CONFLICT_DO_NOTHING			:= rMvConstants.CLOSE_BRACKET || ' ON CONFLICT (policy_id) DO NOTHING'
 
 -- Table and column name definitions
 ------------------------------------------------------------------------------------------------------------------------------------

--- a/BuildScripts/mvConstants.sql
+++ b/BuildScripts/mvConstants.sql
@@ -282,7 +282,7 @@ BEGIN
     rMvConstants.WHERE_NO_DATA                  := ' WHERE 1 = 2 ';
 	rMvConstants.LEFT_OUTER_JOIN				:= 'LOJ';
 	rMvConstants.RIGHT_OUTER_JOIN				:= 'ROJ';
-	rMvConstants.ON_CONFLICT_DO_NOTHING			:= rMvConstants.CLOSE_BRACKET || ' ON CONFLICT (policy_id) DO NOTHING'
+	rMvConstants.ON_CONFLICT_DO_NOTHING			:= rMvConstants.CLOSE_BRACKET || ' ON CONFLICT (policy_id) DO NOTHING';
 
 -- Table and column name definitions
 ------------------------------------------------------------------------------------------------------------------------------------

--- a/BuildScripts/mvTypes.sql
+++ b/BuildScripts/mvTypes.sql
@@ -7,7 +7,7 @@ Revision History    Push Down List
 ------------------------------------------------------------------------------------------------------------------------------------
 Date        | Name          | Description
 ------------+---------------+-------------------------------------------------------------------------------------------------------
-            |               |
+25/03/2021  | D Day         | Added ON_CONFLICT_DO_NOTHING to support workaround for primary key issue
 14/01/2020  | M Revitt      | Changes to fix the array boundaries when doing > 61 materialised views per table
             |               | Added BITMAP_OFFSET
 05/11/2019  | M Revitt      | Changes to allow bitmap column to be manipulated as an array
@@ -171,6 +171,7 @@ AS
     WHERE_NO_DATA                   TEXT,
     LEFT_OUTER_JOIN                 TEXT,
     RIGHT_OUTER_JOIN                TEXT,
+	ON_CONFLICT_DO_NOTHING			TEXT,
 --
 -- Table and column name definitions
 ------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This change is specific to CDL.

This workaround is a fix to stop primary key errors being raised on mv_policy until a permanent product fix has been determined that would work for all materialized views and not impact performance.

At the moment we're mainly seeing this error on mv_policy with limited impact to any of the other materialized views.