### PR TITLE
complete refresh mview log locking fix

### DIFF
--- a/BuildScripts/mvComplexFunctions.sql
+++ b/BuildScripts/mvComplexFunctions.sql
@@ -1238,12 +1238,6 @@ BEGIN
     CALL mv$readdmvindexes (pViewName);
 	CALL mv$dropindexestemptable (pViewName);
 
-    EXCEPTION
-    WHEN OTHERS
-    THEN
-        RAISE INFO      'Exception in procedure mv$refreshMaterializedViewFull';
-        RAISE INFO      'Error %:- %:',     SQLSTATE, SQLERRM;
-        RAISE EXCEPTION '%',                SQLSTATE;
 END;
 $BODY$
 LANGUAGE    plpgsql;

--- a/BuildScripts/mvComplexFunctions.sql
+++ b/BuildScripts/mvComplexFunctions.sql
@@ -1045,7 +1045,7 @@ BEGIN
 			
 				-- Ignore DML changes for forename and surname columns unless the joining createdby or updatedby ID changes on the joining table. This is required ro reduce performance impact
 				-- when these tables get updated with no changes to forename and surname.
-				IF pTableName NOT IN ('prtyinst','personxx','currprty') THEN
+				IF (pViewName = 'mv_insurer_details' OR pTableName NOT IN ('prtyinst','personxx','currprty')) THEN
 
 					FOR i IN ARRAY_LOWER( aMultiTablePgMview.table_array, 1 ) .. ARRAY_UPPER( aMultiTablePgMview.table_array, 1 ) LOOP
 
@@ -1107,7 +1107,7 @@ BEGIN
 		
 			-- Ignore DML changes for forename and surname columns unless the joining createdby or updatedby ID changes on the joining table. This is required ro reduce performance impact
 			-- when these tables get updated with no changes to forename and surname.
-			IF pTableName NOT IN ('prtyinst','personxx','currprty') THEN
+			IF (pViewName = 'mv_insurer_details' OR pTableName NOT IN ('prtyinst','personxx','currprty')) THEN
 		
 				aMultiTablePgMview   := mv$getPgMviewTableData( pConst, pOwner, pViewName );
 

--- a/BuildScripts/mvComplexFunctions.sql
+++ b/BuildScripts/mvComplexFunctions.sql
@@ -956,6 +956,10 @@ Revision History    Push Down List
 ------------------------------------------------------------------------------------------------------------------------------------
 Date        | Name          | Description
 ------------+---------------+-------------------------------------------------------------------------------------------------------
+20/05/2020  | D Day			| Missed temp workaround performance improvement to ignore DML changes to prtyinst, currprty, personxx
+			|				| on MV_DIARY and MV_APPLICATION_EVENTS from second IF statement calls to the same functionality. Also
+			|				| added MV_DOCUMENT to ignore DML changes to prtyinst and personxx. If the main joining table changes
+			|				| this will update the row i.e. createdby or updatedby columns.
 19/11/2020	| D Day			| CDL specific change - temp workaround performance improvement to ignore DML changes to prtyinst, currprty, personxx
 			|				| on MV_DIARY and MV_APPLICATION_EVENTS. The way new client party instances get created even though the forename and surname
 			|				| for Strata users never or rarely changes it still causes the source table row to change and this causes the mview log table
@@ -1041,7 +1045,8 @@ BEGIN
 			IF pQueryJoinsMultiTabCnt > 1 THEN
 			
 				IF (pViewName <> 'mv_diary' AND pTableName NOT IN ('prtyinst','personxx','currprty')) 
-				OR (pViewName <> 'mv_application_events' AND pTableName NOT IN ('prtyinst','personxx','currprty')) THEN
+				OR (pViewName <> 'mv_application_events' AND pTableName NOT IN ('prtyinst','personxx','currprty'))
+				OR (pViewName <> 'mv_document' AND pTableName NOT IN ('prtyinst','personxx')) THEN
 
 					FOR i IN ARRAY_LOWER( aMultiTablePgMview.table_array, 1 ) .. ARRAY_UPPER( aMultiTablePgMview.table_array, 1 ) LOOP
 
@@ -1101,31 +1106,37 @@ BEGIN
 
 		IF pQueryJoinsMultiTabCnt > 1 THEN
 		
-			aMultiTablePgMview   := mv$getPgMviewTableData( pConst, pOwner, pViewName );
+			IF (pViewName <> 'mv_diary' AND pTableName NOT IN ('prtyinst','personxx','currprty')) 
+			OR (pViewName <> 'mv_application_events' AND pTableName NOT IN ('prtyinst','personxx','currprty'))
+			OR (pViewName <> 'mv_document' AND pTableName NOT IN ('prtyinst','personxx')) THEN
+		
+				aMultiTablePgMview   := mv$getPgMviewTableData( pConst, pOwner, pViewName );
 
-			FOR i IN ARRAY_LOWER( aMultiTablePgMview.table_array, 1 ) .. ARRAY_UPPER( aMultiTablePgMview.table_array, 1 ) LOOP
-				
-				IF aMultiTablePgMview.table_array[i] = pTableName THEN
+				FOR i IN ARRAY_LOWER( aMultiTablePgMview.table_array, 1 ) .. ARRAY_UPPER( aMultiTablePgMview.table_array, 1 ) LOOP
+					
+					IF aMultiTablePgMview.table_array[i] = pTableName THEN
+										
+						bOuterJoined := mv$checkIfOuterJoinedTable( pConst, aMultiTablePgMview.table_array[i], aMultiTablePgMview.outer_table_array[i] );
 									
-					bOuterJoined := mv$checkIfOuterJoinedTable( pConst, aMultiTablePgMview.table_array[i], aMultiTablePgMview.outer_table_array[i] );
+									CALL  mv$executeMVFastRefresh
+									(
+										pConst,
+										tLastType,
+										pOwner,
+										pViewName,
+										aMultiTablePgMview.rowid_array[i],
+										aMultiTablePgMview.alias_array[i],
+										bOuterJoined,
+										aMultiTablePgMview.inner_alias_array[i],
+										aMultiTablePgMview.inner_rowid_array[i],
+										uRowIDArray
+									);
 								
-								CALL  mv$executeMVFastRefresh
-								(
-									pConst,
-									tLastType,
-									pOwner,
-									pViewName,
-									aMultiTablePgMview.rowid_array[i],
-									aMultiTablePgMview.alias_array[i],
-									bOuterJoined,
-									aMultiTablePgMview.inner_alias_array[i],
-									aMultiTablePgMview.inner_rowid_array[i],
-									uRowIDArray
-								);
-							
-				END IF;
+					END IF;
+					
+				END LOOP;
 				
-			END LOOP;
+			END IF;
 			
 		ELSE
 	

--- a/BuildScripts/mvComplexFunctions.sql
+++ b/BuildScripts/mvComplexFunctions.sql
@@ -956,10 +956,9 @@ Revision History    Push Down List
 ------------------------------------------------------------------------------------------------------------------------------------
 Date        | Name          | Description
 ------------+---------------+-------------------------------------------------------------------------------------------------------
-20/05/2020  | D Day			| Missed temp workaround performance improvement to ignore DML changes to prtyinst, currprty, personxx
-			|				| on MV_DIARY and MV_APPLICATION_EVENTS from second IF statement calls to the same functionality. Also
-			|				| added MV_DOCUMENT to ignore DML changes to prtyinst and personxx. If the main joining table changes
-			|				| this will update the row i.e. createdby or updatedby columns.
+20/05/2020  | D Day			| Bug fix - to ignore DML changes to prtyinst, currprty, personxx for materialized views that only
+			|				| use these table joins to get forename and surname. If the main joining table changes for the linking id
+			|				| this will update the row i.e. createdby or updatedby columns for the forename and surname.
 19/11/2020	| D Day			| CDL specific change - temp workaround performance improvement to ignore DML changes to prtyinst, currprty, personxx
 			|				| on MV_DIARY and MV_APPLICATION_EVENTS. The way new client party instances get created even though the forename and surname
 			|				| for Strata users never or rarely changes it still causes the source table row to change and this causes the mview log table
@@ -1044,9 +1043,9 @@ BEGIN
 		
 			IF pQueryJoinsMultiTabCnt > 1 THEN
 			
-				IF (pViewName <> 'mv_diary' AND pTableName NOT IN ('prtyinst','personxx','currprty')) 
-				OR (pViewName <> 'mv_application_events' AND pTableName NOT IN ('prtyinst','personxx','currprty'))
-				OR (pViewName <> 'mv_document' AND pTableName NOT IN ('prtyinst','personxx')) THEN
+				-- Ignore DML changes for forename and surname columns unless the joining createdby or updatedby ID changes on the joining table. This is required ro reduce performance impact
+				-- when these tables get updated with no changes to forename and surname.
+				IF pTableName NOT IN ('prtyinst','personxx','currprty') THEN
 
 					FOR i IN ARRAY_LOWER( aMultiTablePgMview.table_array, 1 ) .. ARRAY_UPPER( aMultiTablePgMview.table_array, 1 ) LOOP
 
@@ -1106,9 +1105,9 @@ BEGIN
 
 		IF pQueryJoinsMultiTabCnt > 1 THEN
 		
-			IF (pViewName <> 'mv_diary' AND pTableName NOT IN ('prtyinst','personxx','currprty')) 
-			OR (pViewName <> 'mv_application_events' AND pTableName NOT IN ('prtyinst','personxx','currprty'))
-			OR (pViewName <> 'mv_document' AND pTableName NOT IN ('prtyinst','personxx')) THEN
+			-- Ignore DML changes for forename and surname columns unless the joining createdby or updatedby ID changes on the joining table. This is required ro reduce performance impact
+			-- when these tables get updated with no changes to forename and surname.
+			IF pTableName NOT IN ('prtyinst','personxx','currprty') THEN
 		
 				aMultiTablePgMview   := mv$getPgMviewTableData( pConst, pOwner, pViewName );
 

--- a/UpdateScripts/V301_drop_functs_replaced_by_procedures.sql
+++ b/UpdateScripts/V301_drop_functs_replaced_by_procedures.sql
@@ -45,7 +45,7 @@ BEGIN
 			'mv$removematerializedview',
 			'mv$removematerializedviewlog')) LOOP
 			
-		EXECUTE ech_row.drop_function;
+		EXECUTE each_row.drop_function;
 		
 	END LOOP;
 	

--- a/UpdateScripts/V301_drop_functs_replaced_by_procedures.sql
+++ b/UpdateScripts/V301_drop_functs_replaced_by_procedures.sql
@@ -1,38 +1,52 @@
--- Simple functions
-DROP FUNCTION IF EXISTS mv$addIndexToMvLog$Table;
-DROP FUNCTION IF EXISTS mv$addRow$ToMv$Table;
-DROP FUNCTION IF EXISTS mv$addRow$ToSourceTable;
-DROP FUNCTION IF EXISTS mv$clearSpentPgMviewLogs;
-DROP FUNCTION IF EXISTS mv$createMvLog$Table;
-DROP FUNCTION IF EXISTS mv$createMvLogTrigger;
-DROP FUNCTION IF EXISTS mv$deleteMaterializedViewRows;
-DROP FUNCTION IF EXISTS mv$deletePgMview;
-DROP FUNCTION IF EXISTS mv$deletePgMviewOjDetails;
-DROP FUNCTION IF EXISTS mv$deletePgMviewLog;
-DROP FUNCTION IF EXISTS mv$dropTable;
-DROP FUNCTION IF EXISTS mv$dropTrigger;
-DROP FUNCTION IF EXISTS mv$grantSelectPrivileges;
-DROP FUNCTION IF EXISTS mv$insertPgMviewLogs;
-DROP FUNCTION IF EXISTS mv$removeRow$FromSourceTable;
-DROP FUNCTION IF EXISTS mv$truncateMaterializedView;
---Complex Functions
-DROP FUNCTION IF EXISTS mv$clearAllPgMvLogTableBits;
-DROP FUNCTION IF EXISTS mv$clearPgMvLogTableBits;
-DROP FUNCTION IF EXISTS mv$clearPgMviewLogBit;
-DROP FUNCTION IF EXISTS mv$createPgMv$Table;
-DROP FUNCTION IF EXISTS mv$insertMaterializedViewRows;
-DROP FUNCTION IF EXISTS mv$insertPgMview;
-DROP FUNCTION IF EXISTS mv$insertOuterJoinRows;
-DROP FUNCTION IF EXISTS mv$insertPgMviewOuterJoinDetails;
-DROP FUNCTION IF EXISTS mv$executeMVFastRefresh;
-DROP FUNCTION IF EXISTS mv$refreshMaterializedViewFast;
-DROP FUNCTION IF EXISTS mv$refreshMaterializedViewFull;
-DROP FUNCTION IF EXISTS mv$setPgMviewLogBit;
-DROP FUNCTION IF EXISTS mv$updateMaterializedViewRows;
-DROP FUNCTION IF EXISTS mv$updateOuterJoinColumnsNull;
--- Application Functions
-DROP FUNCTION IF EXISTS mv$createMaterializedView;
-DROP FUNCTION IF EXISTS mv$createMaterializedViewlog;
-DROP FUNCTION IF EXISTS mv$refreshMaterializedView;
-DROP FUNCTION IF EXISTS mv$removeMaterializedView;
-DROP FUNCTION IF EXISTS mv$removeMaterializedViewLog;
+DO $$
+DECLARE
+
+each_row RECORD;
+
+BEGIN
+
+	FOR each_row IN (select 'DROP FUNCTION IF EXISTS '||proname AS drop_function
+	   FROM pg_proc 
+	   WHERE prokind = 'f'
+	   AND proname IN ('mv$addindextomvlog$table',
+			'mv$addindextomvlog$table',
+			'mv$addrow$tomv$table',
+			'mv$addrow$tosourcetable',
+			'mv$clearspentpgmviewlogs',
+			'mv$createmvlog$table',
+			'mv$createmvlogtrigger',
+			'mv$deletematerializedviewrows',
+			'mv$deletepgmview',
+			'mv$deletepgmviewojdetails',
+			'mv$deletepgmviewlog',
+			'mv$droptable',
+			'mv$droptrigger',
+			'mv$grantselectprivileges',
+			'mv$insertpgmviewlogs',
+			'mv$removerow$fromsourcetable',
+			'mv$truncatematerializedview',
+			'mv$clearallpgmvlogtablebits',
+			'mv$clearpgmvlogtablebits',
+			'mv$clearpgmviewlogbit',
+			'mv$createpgmv$table',
+			'mv$insertmaterializedviewrows',
+			'mv$insertpgmview',
+			'mv$insertouterjoinrows',
+			'mv$insertpgmviewouterjoindetails',
+			'mv$executemvfastrefresh',
+			'mv$refreshmaterializedviewfast',
+			'mv$refreshmaterializedviewfull',
+			'mv$setpgmviewlogbit',
+			'mv$updatematerializedviewrows',
+			'mv$updateouterjoincolumnsnull',
+			'mv$creatematerializedview',
+			'mv$creatematerializedviewlog',
+			'mv$refreshmaterializedview',
+			'mv$removematerializedview',
+			'mv$removematerializedviewlog')) LOOP
+			
+		EXECUTE ech_row.drop_function;
+		
+	END LOOP;
+	
+END $$;


### PR DESCRIPTION
Fix complete refresh issue that is causing the mview logs to lock whilst the insert is running which causes delay for any other mviews using the same log.