### PR TITLE
Complete refresh and dynamic delete statement fix

### DIFF
--- a/BuildScripts/mvComplexFunctions.sql
+++ b/BuildScripts/mvComplexFunctions.sql
@@ -1082,7 +1082,7 @@ BEGIN
 			
 				-- Ignore DML changes for forename and surname columns unless the joining createdby or updatedby ID changes on the joining table. This is required ro reduce performance impact
 				-- when these tables get updated with no changes to forename and surname.
-				IF pTableName NOT IN ('prtyinst','personxx','currprty') THEN
+				IF (pViewName = 'mv_insurer_details' OR pTableName NOT IN ('prtyinst','personxx','currprty')) THEN
 
 					FOR i IN ARRAY_LOWER( aMultiTablePgMview.table_array, 1 ) .. ARRAY_UPPER( aMultiTablePgMview.table_array, 1 ) LOOP
 
@@ -1146,7 +1146,7 @@ BEGIN
 		
 			-- Ignore DML changes for forename and surname columns unless the joining createdby or updatedby ID changes on the joining table. This is required ro reduce performance impact
 			-- when these tables get updated with no changes to forename and surname.
-			IF pTableName NOT IN ('prtyinst','personxx','currprty') THEN
+			IF (pViewName = 'mv_insurer_details' OR pTableName NOT IN ('prtyinst','personxx','currprty')) THEN
 		
 				aMultiTablePgMview   := mv$getPgMviewTableData( pConst, pOwner, pViewName );
 

--- a/BuildScripts/mvComplexFunctions.sql
+++ b/BuildScripts/mvComplexFunctions.sql
@@ -3258,9 +3258,17 @@ IF iLeftJoinCnt > 0 THEN
 				'i')-3);
 			
 		IF tJoinTableInfoFound = 'N' THEN
+		
+			IF tTableName = tTableAlias THEN
+		
+				SELECT count(1) INTO iLeftJoinAliasCnt FROM regexp_matches(tLeftJoinLine,tTableName||pConst.ON_TOKEN,'g');
 			
-			SELECT count(1) INTO iLeftJoinAliasCnt FROM regexp_matches(tLeftJoinLine,tTableName||'+[[:space:]]+'||tTableAlias,'g');
-
+			ELSE 
+			
+				SELECT count(1) INTO iLeftJoinAliasCnt FROM regexp_matches(tLeftJoinLine,tTableName||'+[[:space:]]+'||tTableAlias,'g');
+			
+			END IF;
+			
 			IF iLeftJoinAliasCnt > 0 THEN
 				
 				iStartPosition :=  mv$regexpinstr(tLeftJoinLine,pConst.ON_TOKEN,
@@ -3331,8 +3339,16 @@ ELSIF iRightJoinCnt > 0 AND tJoinTableInfoFound = 'N' THEN
 				'i')-3);
 			
 		IF tJoinTableInfoFound = 'N' THEN
+		
+			IF tTableName = tTableAlias THEN
+		
+				SELECT count(1) INTO iRightJoinAliasCnt FROM regexp_matches(tLeftJoinLine,tTableName||pConst.ON_TOKEN,'g');
 			
-			SELECT count(1) INTO iRightJoinAliasCnt FROM regexp_matches(tRightJoinLine,tTableName||'+[[:space:]]+'||tTableAlias,'g');
+			ELSE 
+			
+				SELECT count(1) INTO iRightJoinAliasCnt FROM regexp_matches(tLeftJoinLine,tTableName||'+[[:space:]]+'||tTableAlias,'g');
+			
+			END IF;
 
 			IF iRightJoinAliasCnt > 0 THEN
 				

--- a/BuildScripts/mvComplexFunctions.sql
+++ b/BuildScripts/mvComplexFunctions.sql
@@ -982,10 +982,9 @@ Revision History    Push Down List
 ------------------------------------------------------------------------------------------------------------------------------------
 Date        | Name          | Description
 ------------+---------------+-------------------------------------------------------------------------------------------------------
-20/05/2020  | D Day			| Missed temp workaround performance improvement to ignore DML changes to prtyinst, currprty, personxx
-			|				| on MV_DIARY and MV_APPLICATION_EVENTS from second IF statement calls to the same functionality. Also
-			|				| added MV_DOCUMENT to ignore DML changes to prtyinst and personxx. If the main joining table changes
-			|				| this will update the row i.e. createdby or updatedby columns.
+20/05/2020  | D Day			| Bug fix - to ignore DML changes to prtyinst, currprty, personxx for materialized views that only
+			|				| use these table joins to get forename and surname. If the main joining table changes for the linking id
+			|				| this will update the row i.e. createdby or updatedby columns for the forename and surname.
 19/11/2020	| D Day			| CDL specific change - temp workaround performance improvement to ignore DML changes to prtyinst, currprty, personxx
 			|				| on MV_DIARY and MV_APPLICATION_EVENTS. The way new client party instances get created even though the forename and surname
 			|				| for Strata users never or rarely changes it still causes the source table row to change and this causes the mview log table
@@ -1081,9 +1080,9 @@ BEGIN
 		
 			IF pQueryJoinsMultiTabCnt > 1 THEN
 			
-				IF (pViewName <> 'mv_diary' AND pTableName NOT IN ('prtyinst','personxx','currprty')) 
-				OR (pViewName <> 'mv_application_events' AND pTableName NOT IN ('prtyinst','personxx','currprty'))
-				OR (pViewName <> 'mv_document' AND pTableName NOT IN ('prtyinst','personxx')) THEN
+				-- Ignore DML changes for forename and surname columns unless the joining createdby or updatedby ID changes on the joining table. This is required ro reduce performance impact
+				-- when these tables get updated with no changes to forename and surname.
+				IF pTableName NOT IN ('prtyinst','personxx','currprty') THEN
 
 					FOR i IN ARRAY_LOWER( aMultiTablePgMview.table_array, 1 ) .. ARRAY_UPPER( aMultiTablePgMview.table_array, 1 ) LOOP
 
@@ -1145,9 +1144,9 @@ BEGIN
 
 		IF pQueryJoinsMultiTabCnt > 1 THEN
 		
-			IF (pViewName <> 'mv_diary' AND pTableName NOT IN ('prtyinst','personxx','currprty')) 
-			OR (pViewName <> 'mv_application_events' AND pTableName NOT IN ('prtyinst','personxx','currprty'))
-			OR (pViewName <> 'mv_document' AND pTableName NOT IN ('prtyinst','personxx')) THEN
+			-- Ignore DML changes for forename and surname columns unless the joining createdby or updatedby ID changes on the joining table. This is required ro reduce performance impact
+			-- when these tables get updated with no changes to forename and surname.
+			IF pTableName NOT IN ('prtyinst','personxx','currprty') THEN
 		
 				aMultiTablePgMview   := mv$getPgMviewTableData( pConst, pOwner, pViewName );
 

--- a/BuildScripts/mvComplexFunctions.sql
+++ b/BuildScripts/mvComplexFunctions.sql
@@ -56,6 +56,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 SET     CLIENT_MIN_MESSAGES = ERROR;
 
+DROP PROCEDURE IF EXISTS mv$clearAllPgMvLogTableBitsCompleteRefresh;
 DROP PROCEDURE IF EXISTS mv$clearAllPgMvLogTableBits;
 DROP PROCEDURE IF EXISTS mv$clearPgMvLogTableBits;
 DROP PROCEDURE IF EXISTS mv$clearPgMviewLogBit;
@@ -81,6 +82,92 @@ DROP FUNCTION IF EXISTS mv$outerJoinDeleteStatement;
 
 SET CLIENT_MIN_MESSAGES = NOTICE;
 
+
+--------------------------------------------- Write CREATE-PROCEDURE-FUNCTION-stage scripts --------------------------------------------------
+CREATE OR REPLACE
+PROCEDURE    mv$clearAllPgMvLogTableBitsCompleteRefresh
+            (
+                pConst      IN      mv$allConstants,
+                pOwner      IN      TEXT,
+                pViewName   IN      TEXT
+            )
+AS
+$BODY$
+/* ---------------------------------------------------------------------------------------------------------------------------------
+Routine Name: mv$clearAllPgMvLogTableBitsCompleteRefresh
+Author:       David Day
+Date:         04/05/2021
+------------------------------------------------------------------------------------------------------------------------------------
+Revision History    Push Down List
+------------------------------------------------------------------------------------------------------------------------------------
+Date        | Name          | Description
+------------+---------------+-------------------------------------------------------------------------------------------------------
+04/05/2021  | D Day         | Initial version
+------------+---------------+-------------------------------------------------------------------------------------------------------
+Description:    Performs a full refresh of the materialized view used for Complete Refresh Only, which consists of truncating the table 
+				and then re-populating it.
+
+                This activity also requires that every row in the materialized view log is updated to remove the interest from this
+                materialized view, then as with the fast refresh once all the rows have been processed the materialized view log is
+                cleaned up, in that all rows with a bitmap of zero are deleted as they are then no longer required.
+
+Note:           This procedure requires the SEARCH_PATH to be set to the current value so that the select statement can find the
+                source tables.
+                The default for PostGres procedures is to not use the search path when executing with the privileges of the creator
+
+Arguments:      IN      pConst              The memory structure containing all constants
+         		IN      pOwner              The owner of the object
+                IN      pViewName           The name of the materialized view
+************************************************************************************************************************************
+Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: MIT-0
+***********************************************************************************************************************************/
+DECLARE
+
+    aViewLog        		pg$mview_logs;
+    aPgMview        		pg$mviews;
+	
+	tTableName				TEXT;
+	tDistinctTableArray		TEXT[];
+	
+	iTableAlreadyExistsCnt 	INTEGER DEFAULT 0;
+
+BEGIN
+    aPgMview := mv$getPgMviewTableData( pConst, pOwner, pViewName );
+
+    FOR i IN ARRAY_LOWER( aPgMview.table_array, 1 ) .. ARRAY_UPPER( aPgMview.table_array, 1 )
+    LOOP
+        aViewLog := mv$getPgMviewLogTableData( pConst, aPgMview.table_array[i] );
+		
+		tTableName := aPgMview.table_array[i];		
+		tDistinctTableArray[i] := tTableName;
+		
+		SELECT count(1) INTO STRICT iTableAlreadyExistsCnt 
+		FROM (SELECT unnest(tDistinctTableArray) as table_name) inline
+		WHERE inline.table_name = tTableName;
+		
+		IF iTableAlreadyExistsCnt = 1
+		THEN
+
+			CALL mv$clearPgMvLogTableBits
+						(
+							pConst,
+							aViewLog.owner,
+							aViewLog.pglog$_name,
+							aPgMview.bit_array[i],
+							pConst.MAX_BITMAP_SIZE
+						);
+
+			CALL mv$clearSpentPgMviewLogs( pConst, aViewLog.owner, aViewLog.pglog$_name );
+			
+			COMMIT;
+			
+		END IF;
+
+    END LOOP;
+
+END;
+$BODY$
+LANGUAGE    plpgsql;
 --------------------------------------------- Write CREATE-PROCEDURE-FUNCTION-stage scripts --------------------------------------------------
 CREATE OR REPLACE
 PROCEDURE    mv$clearAllPgMvLogTableBits
@@ -1143,6 +1230,8 @@ Revision History    Push Down List
 ------------------------------------------------------------------------------------------------------------------------------------
 Date        | Name          | Description
 ------------+---------------+-------------------------------------------------------------------------------------------------------
+04/05/2021  | D Day			| Replaced function mv$clearAllPgMvLogTableBits with mv$clearAllPgMvLogTableBitsCompleteRefresh to handle
+			|				| commits during the complete refresh. Removed exception handler to support commits.
 18/08/2020	| J Bills		| Added process to drop and re-index MVs to prevent the refresh from hanging. Also changed the order of 
 			|				| clearing the logs to prevent missing data when base table replication process is running.
 04/06/2020  | D Day         | Change functions with RETURNS VOID to procedures allowing support/control of COMMITS during refresh process.
@@ -1175,17 +1264,11 @@ BEGIN
     CALL mv$createindexestemptable(pOwner, pViewName);
 	CALL mv$dropmvindexes(pOwner, pViewName);
 	CALL mv$truncateMaterializedView(   pConst, pOwner, aPgMview.view_name );
-    CALL mv$clearAllPgMvLogTableBits(   pConst, pOwner, pViewName );
+    CALL mv$clearAllPgMvLogTableBitsCompleteRefresh(   pConst, pOwner, pViewName );
 	CALL mv$insertMaterializedViewRows( pConst, pOwner, pViewName );
     CALL mv$readdmvindexes (pViewName);
 	CALL mv$dropindexestemptable (pViewName);
 
-    EXCEPTION
-    WHEN OTHERS
-    THEN
-        RAISE INFO      'Exception in procedure mv$refreshMaterializedViewFull';
-        RAISE INFO      'Error %:- %:',     SQLSTATE, SQLERRM;
-        RAISE EXCEPTION '%',                SQLSTATE;
 END;
 $BODY$
 LANGUAGE    plpgsql;

--- a/UpdateScripts/V301_drop_functs_replaced_by_procedures.sql
+++ b/UpdateScripts/V301_drop_functs_replaced_by_procedures.sql
@@ -7,7 +7,7 @@ BEGIN
 
 	FOR each_row IN (select 'DROP FUNCTION IF EXISTS '||proname AS drop_function
 	   FROM pg_proc 
-	   W prokind = 'f'
+	   WHERE prokind = 'f'
 	   AND proname IN ('mv$addindextomvlog$table',
 			'mv$addindextomvlog$table',
 			'mv$addrow$tomv$table',

--- a/UpdateScripts/V301_drop_functs_replaced_by_procedures.sql
+++ b/UpdateScripts/V301_drop_functs_replaced_by_procedures.sql
@@ -7,7 +7,7 @@ BEGIN
 
 	FOR each_row IN (select 'DROP FUNCTION IF EXISTS '||proname AS drop_function
 	   FROM pg_proc 
-	   AND prokind = 'f'
+	   W prokind = 'f'
 	   AND proname IN ('mv$addindextomvlog$table',
 			'mv$addindextomvlog$table',
 			'mv$addrow$tomv$table',

--- a/UpdateScripts/V301_drop_functs_replaced_by_procedures.sql
+++ b/UpdateScripts/V301_drop_functs_replaced_by_procedures.sql
@@ -45,7 +45,7 @@ BEGIN
 			'mv$removematerializedview',
 			'mv$removematerializedviewlog')) LOOP
 			
-		EXECUTE ech_row.drop_function;
+		EXECUTE each_row.drop_function;
 		
 	END LOOP;
 	

--- a/UpdateScripts/V301_drop_functs_replaced_by_procedures.sql
+++ b/UpdateScripts/V301_drop_functs_replaced_by_procedures.sql
@@ -1,38 +1,52 @@
--- Simple functions
-DROP FUNCTION IF EXISTS mv$addIndexToMvLog$Table;
-DROP FUNCTION IF EXISTS mv$addRow$ToMv$Table;
-DROP FUNCTION IF EXISTS mv$addRow$ToSourceTable;
-DROP FUNCTION IF EXISTS mv$clearSpentPgMviewLogs;
-DROP FUNCTION IF EXISTS mv$createMvLog$Table;
-DROP FUNCTION IF EXISTS mv$createMvLogTrigger;
-DROP FUNCTION IF EXISTS mv$deleteMaterializedViewRows;
-DROP FUNCTION IF EXISTS mv$deletePgMview;
-DROP FUNCTION IF EXISTS mv$deletePgMviewOjDetails;
-DROP FUNCTION IF EXISTS mv$deletePgMviewLog;
-DROP FUNCTION IF EXISTS mv$dropTable;
-DROP FUNCTION IF EXISTS mv$dropTrigger;
-DROP FUNCTION IF EXISTS mv$grantSelectPrivileges;
-DROP FUNCTION IF EXISTS mv$insertPgMviewLogs;
-DROP FUNCTION IF EXISTS mv$removeRow$FromSourceTable;
-DROP FUNCTION IF EXISTS mv$truncateMaterializedView;
---Complex Functions
-DROP FUNCTION IF EXISTS mv$clearAllPgMvLogTableBits;
-DROP FUNCTION IF EXISTS mv$clearPgMvLogTableBits;
-DROP FUNCTION IF EXISTS mv$clearPgMviewLogBit;
-DROP FUNCTION IF EXISTS mv$createPgMv$Table;
-DROP FUNCTION IF EXISTS mv$insertMaterializedViewRows;
-DROP FUNCTION IF EXISTS mv$insertPgMview;
-DROP FUNCTION IF EXISTS mv$insertOuterJoinRows;
-DROP FUNCTION IF EXISTS mv$insertPgMviewOuterJoinDetails;
-DROP FUNCTION IF EXISTS mv$executeMVFastRefresh;
-DROP FUNCTION IF EXISTS mv$refreshMaterializedViewFast;
-DROP FUNCTION IF EXISTS mv$refreshMaterializedViewFull;
-DROP FUNCTION IF EXISTS mv$setPgMviewLogBit;
-DROP FUNCTION IF EXISTS mv$updateMaterializedViewRows;
-DROP FUNCTION IF EXISTS mv$updateOuterJoinColumnsNull;
--- Application Functions
-DROP FUNCTION IF EXISTS mv$createMaterializedView;
-DROP FUNCTION IF EXISTS mv$createMaterializedViewlog;
-DROP FUNCTION IF EXISTS mv$refreshMaterializedView;
-DROP FUNCTION IF EXISTS mv$removeMaterializedView;
-DROP FUNCTION IF EXISTS mv$removeMaterializedViewLog;
+DO $$
+DECLARE
+
+each_row RECORD;
+
+BEGIN
+
+	FOR each_row IN (select 'DROP FUNCTION IF EXISTS '||proname AS drop_function
+	   FROM pg_proc 
+	   AND prokind = 'f'
+	   AND proname IN ('mv$addindextomvlog$table',
+			'mv$addindextomvlog$table',
+			'mv$addrow$tomv$table',
+			'mv$addrow$tosourcetable',
+			'mv$clearspentpgmviewlogs',
+			'mv$createmvlog$table',
+			'mv$createmvlogtrigger',
+			'mv$deletematerializedviewrows',
+			'mv$deletepgmview',
+			'mv$deletepgmviewojdetails',
+			'mv$deletepgmviewlog',
+			'mv$droptable',
+			'mv$droptrigger',
+			'mv$grantselectprivileges',
+			'mv$insertpgmviewlogs',
+			'mv$removerow$fromsourcetable',
+			'mv$truncatematerializedview',
+			'mv$clearallpgmvlogtablebits',
+			'mv$clearpgmvlogtablebits',
+			'mv$clearpgmviewlogbit',
+			'mv$createpgmv$table',
+			'mv$insertmaterializedviewrows',
+			'mv$insertpgmview',
+			'mv$insertouterjoinrows',
+			'mv$insertpgmviewouterjoindetails',
+			'mv$executemvfastrefresh',
+			'mv$refreshmaterializedviewfast',
+			'mv$refreshmaterializedviewfull',
+			'mv$setpgmviewlogbit',
+			'mv$updatematerializedviewrows',
+			'mv$updateouterjoincolumnsnull',
+			'mv$creatematerializedview',
+			'mv$creatematerializedviewlog',
+			'mv$refreshmaterializedview',
+			'mv$removematerializedview',
+			'mv$removematerializedviewlog')) LOOP
+			
+		EXECUTE ech_row.drop_function;
+		
+	END LOOP;
+	
+END $$;

--- a/UpdateScripts/V602_update_delete_sql.sql
+++ b/UpdateScripts/V602_update_delete_sql.sql
@@ -145,8 +145,16 @@ IF iLeftJoinCnt > 0 THEN
 				'i')-3);
 			
 		IF tJoinTableInfoFound = 'N' THEN
+		
+			IF tTableName = tTableAlias THEN
+		
+				SELECT count(1) INTO iLeftJoinAliasCnt FROM regexp_matches(tLeftJoinLine,tTableName||pConst.ON_TOKEN,'g');
 			
-			SELECT count(1) INTO iLeftJoinAliasCnt FROM regexp_matches(tLeftJoinLine,tTableName||'+[[:space:]]+'||tTableAlias,'g');
+			ELSE 
+			
+				SELECT count(1) INTO iLeftJoinAliasCnt FROM regexp_matches(tLeftJoinLine,tTableName||'+[[:space:]]+'||tTableAlias,'g');
+			
+			END IF;
 
 			IF iLeftJoinAliasCnt > 0 THEN
 				
@@ -218,8 +226,16 @@ ELSIF iRightJoinCnt > 0 AND tJoinTableInfoFound = 'N' THEN
 				'i')-3);
 			
 		IF tJoinTableInfoFound = 'N' THEN
+		
+			IF tTableName = tTableAlias THEN
+		
+				SELECT count(1) INTO iRightJoinAliasCnt FROM regexp_matches(tLeftJoinLine,tTableName||pConst.ON_TOKEN,'g');
 			
-			SELECT count(1) INTO iRightJoinAliasCnt FROM regexp_matches(tRightJoinLine,tTableName||'+[[:space:]]+'||tTableAlias,'g');
+			ELSE 
+			
+				SELECT count(1) INTO iRightJoinAliasCnt FROM regexp_matches(tLeftJoinLine,tTableName||'+[[:space:]]+'||tTableAlias,'g');
+			
+			END IF;
 
 			IF iRightJoinAliasCnt > 0 THEN
 				


### PR DESCRIPTION
Fix complete refresh issue that is causing the mview logs to lock whilst the insert is running which causes delay for any other mviews using the same log.

Fixed issue with DELETE statement when there is no prefix to the JOIN table i.e. JOIN test ON ss.id = test.id.