### PR TITLE
bug fix to resolve dynamic sql build for outer join delete statement

### DIFF
--- a/BuildScripts/mvComplexFunctions.sql
+++ b/BuildScripts/mvComplexFunctions.sql
@@ -3143,6 +3143,7 @@ Revision History    Push Down List
 Date        | Name          | Description
 ------------+---------------+-------------------------------------------------------------------------------------------------------
             |               |
+07/07/2021	| D Day			| Bug fix to resolve syntax issues with the dynamic DELETE statement creation.
 23/02/2021  | D Day      	| Initial version
 ------------+---------------+-------------------------------------------------------------------------------------------------------
 Description:    Function to create outer join delete statement to remove the use of running the full materialized view query.
@@ -3209,6 +3210,8 @@ DECLARE
 	tTable_Alias			TEXT;
 	
 	rec						RECORD;
+	
+	tMatchedTable_Alias		TEXT;
 
 BEGIN
 
@@ -3242,7 +3245,7 @@ tTablesMarkerSQL :=	mv$regexpreplace(tTablesSQL, 'LEFT JOIN',pConst.COMMA_LEFT_T
 tTablesMarkerSQL :=	mv$regexpreplace(tTablesMarkerSQL, 'RIGHT JOIN',pConst.COMMA_RIGHT_TOKEN);
 tTablesMarkerSQL :=	mv$regexpreplace(tTablesMarkerSQL, 'INNER JOIN',pConst.COMMA_INNER_TOKEN);
 tTablesMarkerSQL :=	mv$regexpreplace(tTablesMarkerSQL, 'JOIN',pConst.COMMA_INNER_TOKEN);
-tTablesMarkerSQL :=	mv$regexpreplace(tTablesMarkerSQL, ' ON ',pConst.ON_TOKEN);
+tTablesMarkerSQL :=	mv$regexpreplace(tTablesMarkerSQL,'[[:space:]]+'||'ON ',pConst.ON_TOKEN);
 tTablesMarkerSQL := tTablesMarkerSQL||pConst.COMMA_INNER_TOKEN;
 
 IF iLeftJoinCnt > 0 THEN
@@ -3275,7 +3278,7 @@ IF iLeftJoinCnt > 0 THEN
 			
 			ELSE 
 			
-				SELECT count(1) INTO iLeftJoinAliasCnt FROM regexp_matches(tLeftJoinLine,tTableName||'+[[:space:]]+'||tTableAlias,'g');
+				SELECT count(1) INTO iLeftJoinAliasCnt FROM regexp_matches(tLeftJoinLine,tTableName||pConst.SPACE_CHARACTER||tTableAlias||pConst.ON_TOKEN,'g');
 			
 			END IF;
 			
@@ -3419,7 +3422,9 @@ IF tLeftColumnAlias = tTableAlias THEN
 	
 		tOtherTableName := rec.table_name;
 		tOtherAlias := tRightColumnAlias;
-		tJoinConditions := COALESCE(tLeftJoinConditions,tRightJoinConditions);
+		tJoinConditions := COALESCE(tLeftJoinConditions,tRightJoinConditions);		
+		tJoinConditions := CONCAT(' ', tJoinConditions);		
+		tMatchedTable_Alias := tLeftColumnAlias;
 			
 	END IF;
 	
@@ -3430,6 +3435,8 @@ ELSE
 		tOtherTableName := rec.table_name;
 		tOtherAlias := tLeftColumnAlias;
 		tJoinConditions := COALESCE(tLeftJoinConditions,tRightJoinConditions);
+		tJoinConditions := CONCAT(' ', tJoinConditions);		
+		tMatchedTable_Alias := tRightColumnAlias;
 			
 	END IF;
 
@@ -3437,8 +3444,9 @@ END IF;
 
 END LOOP;
 
-tJoinConditions := REPLACE(tJoinConditions,tTableAlias||'.','src$.');
-tJoinConditions := REPLACE(tJoinConditions,tOtherAlias||'.','src$99.');
+tJoinConditions := REPLACE(tJoinConditions,CONCAT(' ',tMatchedTable_Alias||'.'),' src$.');
+tJoinConditions := REPLACE(tJoinConditions,CONCAT(' ',tOtherAlias||'.'),' src$99.');
+tJoinConditions := LTRIM(tJoinConditions);
 
 IF pWhereClause <> '' THEN
 
@@ -3592,6 +3600,9 @@ IF pWhereClause <> '' THEN
 	END IF;
 	
 END IF;
+
+addWhereClauseJoinConditions := REPLACE(addWhereClauseJoinConditions,CONCAT(' ',tMatchedTable_Alias||'.'),' src$.');
+addWhereClauseJoinConditions := REPLACE(addWhereClauseJoinConditions,CONCAT(' ',tOtherAlias||'.'),' src$99.');
 
 tJoinConditions := CONCAT(tJoinConditions,addWhereClauseJoinConditions);
 

--- a/BuildScripts/mvComplexFunctions.sql
+++ b/BuildScripts/mvComplexFunctions.sql
@@ -3278,7 +3278,7 @@ IF iLeftJoinCnt > 0 THEN
 			
 			ELSE 
 			
-				SELECT count(1) INTO iLeftJoinAliasCnt FROM regexp_matches(tLeftJoinLine,tTableName||pConst.SPACE_CHARACTER||tTableAlias||pConst.ON_TOKEN,'g');
+				SELECT count(1) INTO iLeftJoinAliasCnt FROM regexp_matches(tLeftJoinLine,tTableName||'+[[:space:]]+'||tTableAlias||pConst.ON_TOKEN,'g');
 			
 			END IF;
 			

--- a/UpdateScripts/V602_update_delete_sql.sql
+++ b/UpdateScripts/V602_update_delete_sql.sql
@@ -19,7 +19,7 @@ Revision History    Push Down List
 ------------------------------------------------------------------------------------------------------------------------------------
 Date        | Name          | Description
 ------------+---------------+-------------------------------------------------------------------------------------------------------
-            |               |
+07/07/2021  | D Day         | Defect fix to resolve dynamic sql build for delete statement update.
 23/02/2021  | D Day      	| Initial version
 ------------+---------------+-------------------------------------------------------------------------------------------------------
 Description:    Function to create outer join delete statement to remove the use of running the full materialized view query.

--- a/UpdateScripts/V602_update_delete_sql.sql
+++ b/UpdateScripts/V602_update_delete_sql.sql
@@ -154,7 +154,7 @@ IF iLeftJoinCnt > 0 THEN
 			
 			ELSE 
 			
-				SELECT count(1) INTO iLeftJoinAliasCnt FROM regexp_matches(tLeftJoinLine,tTableName||pConst.SPACE_CHARACTER||tTableAlias||pConst.ON_TOKEN,'g');
+				SELECT count(1) INTO iLeftJoinAliasCnt FROM regexp_matches(tLeftJoinLine,tTableName||'+[[:space:]]+'||tTableAlias||pConst.ON_TOKEN,'g');
 				
 			END IF;
 

--- a/UpdateScripts/V602_update_delete_sql.sql
+++ b/UpdateScripts/V602_update_delete_sql.sql
@@ -507,6 +507,100 @@ $BODY$
 LANGUAGE    plpgsql
 SECURITY    DEFINER;
 
+CREATE OR REPLACE FUNCTION V602_update_delete_sql()
+    RETURNS VOID
+AS
+$BODY$
+
+/* ---------------------------------------------------------------------------------------------------------------------------------
+Routine Name: V602_update_delete_sql
+Author:       David Day
+Date:         10/03/2021
+------------------------------------------------------------------------------------------------------------------------------------
+Revision History    Push Down List
+------------------------------------------------------------------------------------------------------------------------------------
+Date        | Name          | Description
+------------+---------------+-------------------------------------------------------------------------------------------------------
+            |               |
+29/04/2020  | D Day		    | Initial version
+------------+---------------+-------------------------------------------------------------------------------------------------------
+Background:     Postgres does not support Materialized View Fast Refreshes, this suite of scripts is a PL/SQL coded mechanism to
+                provide that functionality, the next phase of this project is to fold these changes into the PostGre kernel.
+Description:    This is a patch script to update the data dictionary pg$mviews_oj_details table new column delete_sql
+				to improve performance of the outer join delete statements. Replacing the full WHERE clause conditions with just
+				the rowid join conditions and linking source tables.
+Notes:          
+Issues:        	https://forums.aws.amazon.com/thread.jspa?messageID=860564
+************************************************************************************************************************************
+Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files
+(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+***********************************************************************************************************************************/
+
+DECLARE
+
+iColumnCnt						INTEGER := 0;
+
+rMviewsOjDetails				RECORD;
+tOuterJoinDeleteStatement 		TEXT;
+iDeleteSqlIsNull				INTEGER := 0;
+
+rConst              			mv$allConstants;
+
+BEGIN
+
+rConst      := mv$buildAllConstants();
+
+SELECT count(1) INTO iColumnCnt
+FROM information_schema.columns 
+WHERE table_name= 'pg$mviews_oj_details'
+AND column_name='join_replacement_from_sql';
+
+IF iColumnCnt = 1 THEN
+
+	FOR rMviewsOjDetails IN (SELECT moj.owner,
+									moj.view_name,
+									moj.table_alias,
+									moj.source_table_name,
+									m.table_names,
+									m.where_clause,
+									m.table_array,
+									m.alias_array
+							 FROM 	pg$mviews_oj_details moj
+							 ,      pg$mviews m
+							 WHERE  moj.view_name = m.view_name
+							 AND 	moj.delete_sql IS NULL) LOOP
+							 
+	tOuterJoinDeleteStatement := V602_mv$outerJoinDeleteStatement(rConst, rMviewsOjDetails.table_names, rMviewsOjDetails.table_alias, rMviewsOjDetails.view_name, rMviewsOjDetails.where_clause, rMviewsOjDetails.source_table_name, rMviewsOjDetails.table_array, rMviewsOjDetails.alias_array);
+
+	UPDATE pg$mviews_oj_details
+	SET delete_sql = tOuterJoinDeleteStatement
+	WHERE view_name = rMviewsOjDetails.view_name
+	AND table_alias = rMviewsOjDetails.table_alias;
+						
+	END LOOP;
+
+	SELECT COUNT(1) INTO iDeleteSqlIsNull
+	FROM   pg$mviews_oj_details
+	WHERE   delete_sql IS NULL;
+
+	IF iDeleteSqlIsNull > 0 THEN
+			RAISE EXCEPTION 'The UPDATE patch script V602_update_delete_sql.sql has not successfully updated all the linking aliases for each mview in data dictionary table pg$mviews_oj_details column delete_sql';
+	END IF;
+	
+END IF;
+
+END;
+$BODY$
+LANGUAGE    plpgsql
+SECURITY    DEFINER;
+
 SELECT V602_update_delete_sql();
 
 DROP FUNCTION V602_update_delete_sql;


### PR DESCRIPTION
There was a defect found when creating the delete statement dynamically to insert into delete_sql column in the outer join configuration table used for the refresh process.