### PR TITLE
Fix batch process retaining previous entries

### DIFF
--- a/BuildScripts/mvComplexFunctions.sql
+++ b/BuildScripts/mvComplexFunctions.sql
@@ -917,6 +917,7 @@ BEGIN
 
             tLastType               := tDmlType;
             iArraySeq               := 1;
+            uRowIDArray             := '{}';
             uRowIDArray[iArraySeq]  := uRowID;
         END IF;
     END LOOP;


### PR DESCRIPTION
First off, thanks for the amazing fast refresh system. It's a huge performance win in our application that manages data collection, aggregation, and visualisation for the health and education sectors in low income settings (see tupaia.org if you're interested)

We have come across an issue where a sequence like "update, update, update, delete" in a log table, followed by a fast refresh, would result in the first update working, but the second two having the related records _deleted from the materialized view_

See the comment inline for what we think was causing this. We've made this change in our fork of the repository and it seems to be working well, but of course we'd appreciate feedback from the experts, and to contribute it back into the base repo if you think it's the right fix.