### PR TITLE
Added deleteOuterJoinRowsComboPK and updated constants

### DIFF
--- a/BuildScripts/mvComplexFunctions.sql
+++ b/BuildScripts/mvComplexFunctions.sql
@@ -64,6 +64,7 @@ DROP PROCEDURE IF EXISTS mv$createPgMv$Table;
 DROP PROCEDURE IF EXISTS mv$insertMaterializedViewRows;
 DROP PROCEDURE IF EXISTS mv$insertPgMview;
 DROP PROCEDURE IF EXISTS mv$insertOuterJoinRows;
+DROP PROCEDURE IF EXISTS mv$deleteOuterJoinRowsComboPK;
 DROP PROCEDURE IF EXISTS mv$insertPgMviewOuterJoinDetails;
 DROP FUNCTION IF EXISTS mv$checkParentToChildOuterJoinAlias;
 DROP PROCEDURE IF EXISTS mv$executeMVFastRefresh;
@@ -866,6 +867,8 @@ Revision History    Push Down List
 ------------------------------------------------------------------------------------------------------------------------------------
 Date        | Name          | Description
 ------------+---------------+-------------------------------------------------------------------------------------------------------
+20/08/2021  | R Achouri     | Added procedure mv$deleteOuterJoinRowsComboPK to handle deletes on outer joining tables with fields that
+			|               | are used as a part of a composite primary key.
 30/03/2021  | D Day			| Added new parameter variables for insert process to handle primary key duplicates on mv_policy when
 			|				| calling procedures mv$updateMaterializedViewRows and mv$insertMaterializedViewRows.
 04/06/2020  | D Day         | Change functions with RETURNS VOID to procedures allowing support/control of COMMITS during refresh process.
@@ -903,16 +906,37 @@ BEGIN
     THEN
 	    IF TRUE = pOuterTable
         THEN	
-		
-			CALL  mv$updateOuterJoinColumnsNull
-							(
-								pConst,
-								pOwner,
-								pViewName,
-								pTableAlias,
-								pRowidColumn,
-								pRowIDArray
-							);
+			IF (pViewName = 'mv_named_driver' AND pTableAlias = 'lcncctgy.')
+				OR (pViewName = 'mv_imtm_employment_activity' AND pTableAlias = 'a.')
+				OR (pViewName = 'mv_imtm_professional_indemnity' AND pTableAlias = 'q.')
+				OR (pViewName = 'mv_imtm_prsnal_accident_cover' AND pTableAlias = 'm.')
+				OR (pViewName = 'mv_imtm_travel_addtional_cover' AND pTableAlias = 'a.')
+				OR (pViewName = 'mv_bstr_addl_cover_options' AND pTableAlias = 'o.')
+				OR (pViewName = 'mv_instalment_scheme_settings' AND pTableAlias = 'if.')
+				OR (pViewName = 'mv_bsca_caravan_cover_det' AND pTableAlias = 'b.')				
+				OR (pViewName = 'mv_imtm_gen_bus_trade_details' AND pTableAlias = 'td.') 
+				THEN
+				CALL  mv$deleteOuterJoinRowsComboPK
+								(
+									pConst,
+									pOwner,
+									pViewName,
+									pInnerAlias,
+									pInnerRowid,
+									pRowidColumn,
+									pRowIDArray
+								);					
+			ELSE
+				CALL  mv$updateOuterJoinColumnsNull
+								(
+									pConst,
+									pOwner,
+									pViewName,
+									pTableAlias,
+									pRowidColumn,
+									pRowIDArray
+								);
+			END IF;
 		
 		ELSE
 			CALL mv$deleteMaterializedViewRows( pConst, pOwner, pViewName, pConst.DELETE_DML_TYPE, pRowidColumn, pRowIDArray );
@@ -1499,6 +1523,101 @@ END;
 $BODY$
 LANGUAGE    plpgsql;
 
+------------------------------------------------------------------------------------------------------------------------------------
+CREATE OR REPLACE
+PROCEDURE    mv$deleteOuterJoinRowsComboPK
+            (
+                pConst          IN      mv$allConstants,
+                pOwner          IN      TEXT,
+                pViewName       IN      TEXT,
+                pInnerAlias     IN      TEXT,
+                pInnerRowid     IN      TEXT,
+				pRowidColumn	IN 		TEXT,
+                pRowIDs         IN      UUID[]
+            )
+AS
+$BODY$
+/* ---------------------------------------------------------------------------------------------------------------------------------
+Routine Name: mv$deleteOuterJoinRowsComboPK
+Author:       Rami Achouri
+Date:         19/08/2021
+------------------------------------------------------------------------------------------------------------------------------------
+Revision History    Push Down List
+------------------------------------------------------------------------------------------------------------------------------------
+Date        | Name          | Description
+------------+---------------+-------------------------------------------------------------------------------------------------------
+19/08/2021  | R Achouri     | Initial version
+------------+---------------+-------------------------------------------------------------------------------------------------------
+Description:    Procedure that handles deletes on outer joining tables with fields that are used as a part of a composite primary key
+				on a materialized view table.
+
+Arguments:      IN      pConst              The memory structure containing all constants
+                IN		pOwner
+                IN		pViewName
+                IN		pInnerAlias
+                IN		pInnerRowid
+				IN 		pRowidColumn
+                IN		pRowIDs
+
+************************************************************************************************************************************
+Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: MIT-0
+***********************************************************************************************************************************/
+DECLARE
+
+    aPgMview        	pg$mviews;
+	tFromClause			TEXT;
+    tSqlStatement   	TEXT;
+	tParent_array		UUID[];
+
+BEGIN
+
+    aPgMview  := mv$getPgMviewTableData( pConst, pOwner, pViewName );
+	
+	tSqlStatement :=  pConst.SELECT_ARRAY			|| 
+					  pConst.DISTINCT_CLAUSE		|| pInnerRowid             || pConst.FROM_COMMAND			   ||
+					  aPgMview.owner           		|| pConst.DOT_CHARACTER    || aPgMview.view_name			   ||
+					  pConst.WHERE_COMMAND			|| pRowidColumn   		   || pConst.IN_ROWID_LIST			   ||
+					  pConst.CLOSE_BRACKET;
+					
+	EXECUTE tSqlStatement 
+	USING pRowIDs INTO tParent_array;
+		
+	tSqlStatement :=  pConst.DELETE_FROM || pOwner  || pConst.DOT_CHARACTER   || pViewName        ||
+							pConst.WHERE_COMMAND    || pInnerRowid          || pConst.IN_ROWID_LIST;
+	
+	EXECUTE tSqlStatement 
+	USING tParent_array;
+	
+	tFromClause	 := pConst.FROM_COMMAND  || aPgMview.table_names    || pConst.WHERE_COMMAND;
+
+    IF LENGTH( aPgMview.where_clause ) > 0
+    THEN
+		tFromClause := tFromClause      || aPgMview.where_clause    || pConst.AND_COMMAND;
+
+    END IF;
+	
+    tFromClause := tFromClause  || pInnerAlias   || pConst.DOT_CHARACTER    || pConst.MV_M_ROW$_SOURCE_COLUMN   || pConst.IN_ROWID_LIST;
+
+    tSqlStatement :=    pConst.INSERT_INTO       ||
+                        aPgMview.owner           || pConst.DOT_CHARACTER    || aPgMview.view_name   ||
+                        pConst.OPEN_BRACKET      || aPgMview.pgmv_columns   || pConst.CLOSE_BRACKET ||
+                        pConst.SELECT_COMMAND    || aPgMview.select_columns ||
+                        tFromClause;
+	
+	EXECUTE tSqlStatement
+	USING tParent_array;
+	
+
+    EXCEPTION
+    WHEN OTHERS
+    THEN
+        RAISE INFO      'Exception in procedure mv$deleteOuterJoinRowsComboPK';
+        RAISE INFO      'Error %:- %:',     SQLSTATE, SQLERRM;
+        RAISE INFO      'Error Context:% %',CHR(10),  tSqlStatement;
+        RAISE EXCEPTION '%',                SQLSTATE;
+END;
+$BODY$
+LANGUAGE    plpgsql;
 ------------------------------------------------------------------------------------------------------------------------------------
 CREATE OR REPLACE
 PROCEDURE    mv$insertPgMviewOuterJoinDetails

--- a/BuildScripts/mvConstants.sql
+++ b/BuildScripts/mvConstants.sql
@@ -283,6 +283,8 @@ BEGIN
 	rMvConstants.LEFT_OUTER_JOIN				:= 'LOJ';
 	rMvConstants.RIGHT_OUTER_JOIN				:= 'ROJ';
 	rMvConstants.ON_CONFLICT_DO_NOTHING			:= rMvConstants.CLOSE_BRACKET || ' ON CONFLICT (policy_id) DO NOTHING';
+	rMvConstants.DISTINCT_CLAUSE				:= 'DISTINCT ';
+	rMvConstants.SELECT_ARRAY					:= 'SELECT ARRAY(SELECT ';
 
 -- Table and column name definitions
 ------------------------------------------------------------------------------------------------------------------------------------

--- a/BuildScripts/mvTypes.sql
+++ b/BuildScripts/mvTypes.sql
@@ -7,6 +7,7 @@ Revision History    Push Down List
 ------------------------------------------------------------------------------------------------------------------------------------
 Date        | Name          | Description
 ------------+---------------+-------------------------------------------------------------------------------------------------------
+19/08/2021  | R Achouri     | Added DISTINCT_CLAUSE and SELECT_ARRAY
 25/03/2021  | D Day         | Added ON_CONFLICT_DO_NOTHING to support workaround for primary key issue
 14/01/2020  | M Revitt      | Changes to fix the array boundaries when doing > 61 materialised views per table
             |               | Added BITMAP_OFFSET
@@ -172,6 +173,8 @@ AS
     LEFT_OUTER_JOIN                 TEXT,
     RIGHT_OUTER_JOIN                TEXT,
 	ON_CONFLICT_DO_NOTHING			TEXT,
+    DISTINCT_CLAUSE                 TEXT,
+    SELECT_ARRAY                    TEXT,
 --
 -- Table and column name definitions
 ------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Added procedure to handle deletes on outer joining tables with fields that are used as a part of a composite primary key on a materialized view table.